### PR TITLE
chore: migrate to cn for Tailwind class merging

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@base-ui/react": "^1.7.0",
     "class-variance-authority": "^0.7.1",
-    "cnfast": "^0.1.0",
+    "cn": "^0.2.3",
     "lucide-react": "^1.35.0",
     "motion": "^13.1.1",
     "shadcn": "^4.19.0",

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,1 +1,1 @@
-export { cn } from "cnfast";
+export { cn } from "cn";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,9 +947,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      cnfast:
-        specifier: ^0.1.0
-        version: 0.1.0
+      cn:
+        specifier: ^0.2.3
+        version: 0.2.3
       lucide-react:
         specifier: ^1.35.0
         version: 1.35.0(react@19.2.8)
@@ -3606,8 +3606,9 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cnfast@0.1.0:
-    resolution: {integrity: sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ==}
+  cn@0.2.3:
+    resolution: {integrity: sha512-z1S2v7FdtqcoXQzJWqNPBJ3KPG1or9FlefB0x+Eu8322BMmCSSVqzeI7itNj/6YRjyendnlWDJnKQkBhukT3fg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   code-block-writer@13.0.3:
@@ -7537,7 +7538,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cnfast@0.1.0: {}
+  cn@0.2.3: {}
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
## What

Swaps `cnfast` for [`cn`](https://github.com/shadcn-ui/cn), shadcn's own class-merging engine — the package the shadcn registry now standardises on. Conflict-resolution semantics match `tailwind-merge` v3.

Run with `npx shadcn@latest migrate cn` from `packages/ui` (from the workspace root it fails on `ERR_PNPM_ADDING_TO_ROOT`).

## Changes

- `packages/ui/src/lib/utils.ts`: `export { cn } from "cnfast"` → `export { cn } from "cn"`
- `packages/ui/package.json`: `cnfast` → `cn`
- lockfile updated

## Verification

`pnpm lint`, `pnpm format` and 23 of 24 `typecheck` tasks pass. `@repo/web#typecheck` fails with the same 28 errors on `main` (the TanStack Router generated route tree is absent until a dev/build run), so it is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fuAGAmG66YvgRKtrkidAV

---
_Generated by [Claude Code](https://claude.ai/code/session_011fuAGAmG66YvgRKtrkidAV)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps `cnfast` for `cn`, shadcn's class-merging engine, so the UI package matches what the shadcn registry now standardizes on. Conflict-resolution semantics match `tailwind-merge` v3.

To re-run the migration, run `npx shadcn@latest migrate cn` from `packages/ui`; it fails from the workspace root with a pnpm error.

`pnpm lint` and `pnpm format` pass. The `@repo/web#typecheck` failure is pre-existing on `main` and unrelated.

<sup>Written for commit c11465cdad8aa7878383a709c6b8999d753ce9c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

