### PR TITLE
games worker: stop double-gzipping GLBs (encodeBody manual)

### DIFF
--- a/apps/games/src/index.ts
+++ b/apps/games/src/index.ts
@@ -142,7 +142,16 @@ export default {
     }
 
     const body = compress ? obj.body.pipeThrough(new CompressionStream("gzip")) : obj.body;
-    const response = new Response(body, { headers });
+    // The body is ALREADY gzip when `compress` is set. Without `encodeBody:
+    // "manual"` the runtime reads `content-encoding: gzip` as an instruction
+    // and gzips it again; the browser then strips one layer and hands the
+    // loader gzip bytes. Every GLB on every game failed to parse this way, and
+    // Miniflare hid it — it drops `content-encoding` from the response it
+    // hands a test, so the double layer never reached an assertion.
+    const response = new Response(body, {
+      headers,
+      encodeBody: compress ? "manual" : "automatic",
+    });
 
     if (cacheable) {
       ctx.waitUntil(caches.default.put(cacheKey, toCache(response.clone(), headers, compress)));
@@ -191,7 +200,8 @@ function fromCache(hit: Response): Response {
   const headers = new Headers(hit.headers);
   headers.delete(ENCODING_MARKER);
   headers.set("content-encoding", encoding);
-  return new Response(hit.body, { headers });
+  // Same rule as the cold path: the cached octets are the gzip we made.
+  return new Response(hit.body, { headers, encodeBody: "manual" });
 }
 
 /**

--- a/apps/games/tests/worker.mjs
+++ b/apps/games/tests/worker.mjs
@@ -9,15 +9,21 @@
 //     with `identity` still reaches the worker as gzip-capable. Whether a
 //     non-gzip client gets a plain body is negotiated by Cloudflare's edge and
 //     is not observable from inside Miniflare.
-//   * Miniflare strips `content-encoding` off the response it hands back
-//     without decoding the body, so compression is asserted on the bytes.
+//   * Miniflare's dispatchFetch behaves like a browser: it decodes exactly ONE
+//     `content-encoding` layer and strips the header. A correctly encoded
+//     body therefore arrives here as the ORIGINAL bytes, and gzip magic in a
+//     body means the worker wrapped it twice — which is exactly what the old
+//     assertions were passing on (the runtime re-encoded a body that already
+//     carried `content-encoding: gzip`, and the harness peeled one layer).
+//     That compression happens at all is asserted through `vary`; the wire
+//     bytes are checked against prod with
+//     `curl -sH 'Accept-Encoding: gzip' <glb> | gunzip | head -c4` → `glTF`.
 //
 // miniflare is held at 4.x on purpose. npm's `latest` is a 5.x -alpha that
 // replaces the top-level single-worker options below with a per-worker
 // `config` object; adopting it is a migration, not a version bump. Don't let a
 // blanket dependency update carry this one along.
 import { Miniflare } from "miniflare";
-import { gunzipSync } from "node:zlib";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -86,12 +92,16 @@ check(
   cold.headers.get("content-type") === "model/gltf-binary",
   cold.headers.get("content-type") ?? "none",
 );
-check("glb body gzipped", isGzip(coldBody));
 check("vary: accept-encoding set", (cold.headers.get("vary") ?? "").includes("accept-encoding"));
 check("cold request reports a cache miss", cold.headers.get("x-vg-cache") === "miss");
+// Regression: a Response built with `content-encoding: gzip` and no
+// `encodeBody: "manual"` is gzipped a second time by the runtime. The harness
+// peels one layer, so the bug shows up here as a gzip-magic body of the wrong
+// length rather than the model.
 check(
-  "gzip round-trips to the original bytes",
-  isGzip(coldBody) && gunzipSync(coldBody).equals(glb),
+  "glb arrives as the model, not a second gzip layer",
+  coldBody.equals(glb),
+  isGzip(coldBody) ? `double-encoded (${coldBody.length} bytes of gzip)` : `${coldBody.length} bytes`,
 );
 
 // ---- edge cache ------------------------------------------------------------
@@ -99,13 +109,13 @@ await new Promise((r) => setTimeout(r, 300));
 const warm = await get("/models/hero.glb");
 const warmBody = await body(warm);
 check("second request is an edge-cache hit", warm.headers.get("x-vg-cache") === "hit");
-// Regression: putting a self-compressed body into the Cache API with
-// content-encoding still set gets it encoded a second time, and every cached
-// model comes back as gzip-inside-gzip.
+// Regression: the cached copy is our own gzip stored as opaque octets; the
+// rebuilt Response must carry it out with the encoding declared AND marked
+// manual, or the hit path double-encodes even when the cold path is right.
 check(
-  "cache hit is not double-encoded",
-  isGzip(warmBody) && gunzipSync(warmBody).equals(glb),
-  `${coldBody.length} cold vs ${warmBody.length} warm bytes`,
+  "cache hit arrives as the model, not a second gzip layer",
+  warmBody.equals(glb),
+  isGzip(warmBody) ? `double-encoded (${warmBody.length} bytes of gzip)` : `${warmBody.length} bytes`,
 );
 
 // ---- payloads that must be left alone --------------------------------------


### PR DESCRIPTION
## What

`apps/games` gzips `model/gltf-binary` itself and sets `content-encoding: gzip`. The Response was built without `encodeBody: "manual"`, so the Workers runtime encoded the already-gzipped body a second time. Browsers strip one layer, GLTFLoader receives gzip bytes, and `[assets] failed to load … is not valid JSON` fires for every model on every 3D game.

Live since the mobile sweep (423eb20a, 2026-08-11). Fingerprint on prod:

```
curl -sH 'Accept-Encoding: gzip' https://crazy-waymo.vibedgames.com/models/cars/taxi.glb | gunzip | head -c4   # 1f8b… (needs a second gunzip to reach glTF)
```

In crazy-waymo it showed up as `rest items ok 44873 dropSrc 52366`: half the baked city dropped because its GLB never parsed.

## Fix

`encodeBody: "manual"` on the compressed cold-path Response and on the `fromCache` rebuild. Cached entries self-heal: they hold our single gzip as opaque octets, so the hit path serves them correctly without a purge.

## Test

The Miniflare check was green *because* of the bug: `dispatchFetch` peels exactly one `content-encoding` layer, so a double-encoded body looked like a correct single gzip. Assertions now expect the original bytes back and fail against the old worker (verified by stashing the fix: both regression checks FAIL with "double-encoded"). Harness comment rewritten to say what Miniflare actually does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops GLB responses from being gzip-encoded twice. Previously, `apps/games` manually gzipped GLBs but the Workers runtime encoded them again, leaving `GLTFLoader` with gzip bytes after the browser removed one layer; cold and cache-hit responses now serve the original model correctly without purging cached entries.

**Bug Fixes**

- Marks manually compressed response bodies with `encodeBody: "manual"` on both paths.
- Adds regression checks for cold and cache-hit responses and documents Miniflare’s one-layer decoding behavior.

<sup>Written for commit 3b3a04a9a534e218fba1f7361394635183be7b1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

