### PR TITLE
crazy-waymo: recover rejected parcels, surface lots for the rest

### DIFF
--- a/games/crazy-waymo/CLAUDE.md
+++ b/games/crazy-waymo/CLAUDE.md
@@ -119,7 +119,15 @@ bake-network.mts`) from the same park-cleared polylines — car-free-park
   solids out of lanes, the kind mix and the vertex budgets. The kit frontage
   walk still fills the city OUTSIDE the surveyed footprints (west and south);
   inside them it is skipped cell by cell (`covered`), so a rejected parcel
-  leaves a lot, never a kit house in the middle of a terrace.
+  leaves a lot, never a kit house in the middle of a terrace. Rejection is
+  the last resort: a folded ring is rebuilt as its own box, a ring that spans
+  a street is cut at the kerb and the larger side kept, a parcel under a
+  viaduct is built to the storeys that clear the soffit (`freewaySoffitAt`),
+  and what still cannot stand — no room for one storey, a pillar in the plan
+  — is emitted as a surface lot (`ParcelLot`: draped asphalt, bay lines,
+  parked cars) so the survey never leaves raw ground. The ~500 that remain
+  are MEDIAN parcels between the two edges of a divided boulevard; the road
+  is drawn over them and `pnpm test` carries them as a baseline.
 - **Two load paths, and only some builders run on both.** `buildLandmarks`,
   `buildFreeways` and `buildPiers` are rebuilt live on the cold-gen path AND
   the baked-rest path. `buildGoldenGate` runs on cold gen ONLY — its meshes go

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -1493,13 +1493,14 @@ export class CityModel {
         network: this.network,
         terrain: this.terrain,
         reserved: this.reservedCells,
+        standAt: (x, z) => this.standAt(x, z),
       });
       const s = this.parcelPlanCache.stats;
       console.log(
         `[city] parcels planned: ${s.built} built (${s.onRoad} in a lane, ${s.clipped} clipped away, ` +
           `${s.stacked} stacked, ${s.park} park, ${s.reserved} reserved, ${s.freeway} freeway, ` +
           `${s.folded} folded, ${s.straddle} straddling, ${s.cliff} cliff, ${s.water} water; ` +
-          `${s.movedVerts} verts moved, ${s.stretched} stretched) ` +
+          `${s.movedVerts} verts moved, ${s.stretched} stretched; ${s.underDeck} under a deck, ${s.boxed} boxed, ${s.split} split, ${s.lots} lots) ` +
           `${Math.round(performance.now() - t0)}ms`,
       );
     }
@@ -1507,9 +1508,10 @@ export class CityModel {
   }
   private async buildParcels(): Promise<void> {
     const t0 = performance.now();
-    const { plans } = this.parcelPlan();
+    const { plans, lots } = this.parcelPlan();
     const built = await buildParcelFabric(
       plans,
+      lots,
       { imposter: IMPOSTER_DISTANCE, midImposter: MID_IMPOSTER_DISTANCE, detail: DETAIL_DISTANCE },
       parcelDetailLevel(),
       () => this.breathe(),
@@ -1519,8 +1521,9 @@ export class CityModel {
       this.chunks.push({ cx: c.cx, cz: c.cz, radius: c.radius, dist: c.dist, group: c.group });
     }
     for (const p of plans) for (const so of p.solids) this.solids.push(so);
+    this.parkedCarSpecs = [...this.parkedCarSpecs, ...built.parkedCars];
     console.log(
-      `[city] parcels built: ${plans.length} buildings, ${built.stats.vertices} verts, ` +
+      `[city] parcels built: ${plans.length} buildings, ${lots.length} lots (${built.parkedCars.length} cars), ${built.stats.vertices} verts, ` +
         `${built.stats.buffers} buffers in ${Math.round(performance.now() - t0)}ms`,
     );
   }

--- a/games/crazy-waymo/src/world/freeways.ts
+++ b/games/crazy-waymo/src/world/freeways.ts
@@ -1116,6 +1116,87 @@ export function nearFreeway(x: number, z: number, margin: number): boolean {
 // Deck + inner-barrier triangles for the static physics trimesh — the car
 // drives the exact rendered surface. Streets keep the heightfield below:
 // wheel rays cast from under the deck never reach it, so underpasses work.
+/**
+ * Height of the deck UNDERSIDE over a point, or null when no deck covers it
+ * (within `half + margin` of a centreline). The lowest covering deck wins,
+ * which is what a building's roof has to clear. Ramps descend to grade, so a
+ * parcel under a ramp mouth gets a soffit at ground level and nothing fits —
+ * the right answer, since that is where the ramp lands.
+ */
+type DeckSample = readonly [
+  ax: number,
+  az: number,
+  bx: number,
+  bz: number,
+  ya: number,
+  yb: number,
+  lim: number,
+];
+const soffitHash = new Map<string, DeckSample[]>();
+let soffitHashFor: FreewayBuild | null = null;
+const SOFFIT_CELL = 60;
+function buildSoffitHash(build: FreewayBuild): void {
+  if (soffitHashFor === build) return;
+  soffitHashFor = build;
+  soffitHash.clear();
+  for (const line of build.lines) {
+    const pts = line.pts;
+    for (let i = 0; i + 1 < pts.length; i++) {
+      const [ax, az] = pts[i] ?? [0, 0];
+      const [bx, bz] = pts[i + 1] ?? [0, 0];
+      const s: DeckSample = [ax, az, bx, bz, line.ys[i] ?? 0, line.ys[i + 1] ?? 0, line.half + 1];
+      for (
+        let cx = Math.floor((Math.min(ax, bx) - 12) / SOFFIT_CELL);
+        cx <= Math.floor((Math.max(ax, bx) + 12) / SOFFIT_CELL);
+        cx++
+      ) {
+        for (
+          let cz = Math.floor((Math.min(az, bz) - 12) / SOFFIT_CELL);
+          cz <= Math.floor((Math.max(az, bz) + 12) / SOFFIT_CELL);
+          cz++
+        ) {
+          const k = `${cx},${cz}`;
+          const arr = soffitHash.get(k) ?? [];
+          arr.push(s);
+          soffitHash.set(k, arr);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Height of the deck UNDERSIDE over a point, or null when no deck covers it
+ * (within `half + margin` of a centreline, margin at most 1). The lowest
+ * covering deck wins, which is what a building's roof has to clear. Ramps
+ * descend to grade, so a parcel under a ramp mouth gets a soffit at ground
+ * level and nothing fits — the right answer, since that is where the ramp
+ * lands.
+ */
+export function freewaySoffitAt(
+  terrain: Terrain,
+  network: RoadNetwork | undefined,
+  x: number,
+  z: number,
+  margin: number,
+): number | null {
+  buildSoffitHash(buildData(terrain, network));
+  const segs = soffitHash.get(`${Math.floor(x / SOFFIT_CELL)},${Math.floor(z / SOFFIT_CELL)}`);
+  if (!segs) return null;
+  let soffit: number | null = null;
+  for (const [ax, az, bx, bz, ya, yb, lim0] of segs) {
+    const lim = lim0 - 1 + Math.min(margin, 1);
+    const dx = bx - ax;
+    const dz = bz - az;
+    const l2 = dx * dx + dz * dz;
+    const t = l2 > 1e-8 ? Math.min(Math.max(((x - ax) * dx + (z - az) * dz) / l2, 0), 1) : 0;
+    if (Math.hypot(ax + dx * t - x, az + dz * t - z) >= lim) continue;
+    const y = ya + (yb - ya) * t - DECK_T;
+    if (soffit === null || y < soffit) soffit = y;
+  }
+  return soffit;
+}
+
 /** Pillar footprints of the memoized build — `pnpm test` asserts none sit in a street. */
 export function freewayPillars(terrain: Terrain, network?: RoadNetwork): readonly PillarSpot[] {
   return buildData(terrain, network).pillars;

--- a/games/crazy-waymo/src/world/parcel-build.ts
+++ b/games/crazy-waymo/src/world/parcel-build.ts
@@ -10,7 +10,11 @@ import {
   type ParcelMaterial,
   tierDistance,
 } from "./parcel-mesh";
-import type { ParcelPlan } from "./parcel-plan";
+import { TRAFFIC_CARS } from "../assets/manifest";
+import { ROAD_TILE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { Rng } from "../shared/rng";
+import type { ParkedSpec } from "./furniture";
+import { distToRing, type ParcelLot, type ParcelPlan, pointInRing } from "./parcel-plan";
 
 // The parcel fabric is built LIVE on both load paths, like the freeways and
 // piers — never captured into rest.bin. Three reasons, each sufficient:
@@ -81,6 +85,8 @@ export type ParcelChunk = {
 export type ParcelBuild = {
   readonly chunks: readonly ParcelChunk[];
   readonly stats: ParcelGeoStats;
+  /** Cars on the surface lots — punt-able bodies like the kerb parking. */
+  readonly parkedCars: readonly ParkedSpec[];
 };
 
 export type ParcelBands = {
@@ -111,11 +117,12 @@ function geometryOf(g: ParcelGeo): THREE.BufferGeometry {
  */
 export async function buildParcelFabric(
   plans: readonly ParcelPlan[],
+  lots: readonly ParcelLot[],
   bands: ParcelBands,
   detail: DetailLevel,
   onBreathe?: () => Promise<void>,
 ): Promise<ParcelBuild> {
-  const { geos, stats } = await buildParcelGeometry(plans, detail, onBreathe);
+  const { geos, stats } = await buildParcelGeometry(plans, detail, onBreathe, lots);
   const detailDist = bands.detail * liveQuality().detailScale;
   const groups = new Map<string, ParcelChunk>();
   for (const g of geos) {
@@ -135,5 +142,109 @@ export async function buildParcelFabric(
     mesh.matrixAutoUpdate = false;
     chunk.group.add(mesh);
   }
-  return { chunks: [...groups.values()], stats };
+  return { chunks: [...groups.values()], stats, parkedCars: parkOnLots(lots, plans) };
+}
+
+// A car is ~2.75u long and 1.5u wide. Bays nose in toward the lot's long
+// sides at the pitch the paint uses (parcel-mesh.ts BAY_PITCH); a lot too
+// narrow for bays parks a single line along its length instead. Every spot
+// is tested against the lot's own outline and its pillars, so a car never
+// pokes into the street or stands in a footing.
+const CAR_HALF_LEN = 1.4;
+const CAR_HALF_W = 0.8;
+const BAY_PITCH = 2.2;
+
+/**
+ * Buildings bucketed on the street grid, so a car can ask whether it would
+ * stand inside one. A lot ring is often a GROUP outline (the extractor's
+ * bbox fallback) with a real parcel's building inside it, and a car parked
+ * through that building's wall is the one place the two passes meet.
+ */
+class BuildingIndex {
+  private readonly cells = new Map<number, ParcelPlan[]>();
+  constructor(plans: readonly ParcelPlan[]) {
+    for (const p of plans) {
+      const r = Math.hypot(p.obb.halfA, p.obb.halfB) + 1;
+      for (let gx = this.gx(p.obb.cx - r); gx <= this.gx(p.obb.cx + r); gx++) {
+        for (let gz = this.gz(p.obb.cz - r); gz <= this.gz(p.obb.cz + r); gz++) {
+          const k = gx * 1024 + gz;
+          const arr = this.cells.get(k);
+          if (arr) arr.push(p);
+          else this.cells.set(k, [p]);
+        }
+      }
+    }
+  }
+  private gx(x: number): number {
+    return Math.floor((x + WORLD_HALF_X) / ROAD_TILE);
+  }
+  private gz(z: number): number {
+    return Math.floor((z + WORLD_HALF_Z) / ROAD_TILE);
+  }
+  /** Inside any building's box, dilated by `pad`. */
+  inside(x: number, z: number, pad: number): boolean {
+    for (const p of this.cells.get(this.gx(x) * 1024 + this.gz(z)) ?? []) {
+      const dx = x - p.obb.cx;
+      const dz = z - p.obb.cz;
+      const a = dx * p.obb.ex + dz * p.obb.ez;
+      const b = -dx * p.obb.ez + dz * p.obb.ex;
+      if (Math.abs(a) < p.obb.halfA + pad && Math.abs(b) < p.obb.halfB + pad) return true;
+    }
+    return false;
+  }
+}
+
+function parkOnLots(lots: readonly ParcelLot[], plans: readonly ParcelPlan[]): ParkedSpec[] {
+  const out: ParkedSpec[] = [];
+  const buildings = new BuildingIndex(plans);
+  for (const lot of lots) {
+    const rng = new Rng(lot.seed ^ 0x51ed);
+    const o = lot.obb;
+    const long = o.halfA >= o.halfB;
+    const lx = long ? o.ex : -o.ez;
+    const lz = long ? o.ez : o.ex;
+    const sx = long ? -o.ez : o.ex;
+    const sz = long ? o.ex : o.ez;
+    const halfL = long ? o.halfA : o.halfB;
+    const halfS = long ? o.halfB : o.halfA;
+    const clear = (x: number, z: number, r: number): boolean => {
+      if (!pointInRing(lot.ring, lot.n, x, z)) return false;
+      if (distToRing(lot.ring, lot.n, x, z) < r) return false;
+      if (buildings.inside(x, z, CAR_HALF_LEN)) return false;
+      for (const p of lot.pillars) {
+        if (Math.hypot(p.x - x, p.z - z) < p.half + CAR_HALF_LEN + 0.4) return false;
+      }
+      return true;
+    };
+    const place = (x: number, z: number, nx: number, nz: number, r: number): void => {
+      if (!clear(x, z, r) || !rng.chance(0.78)) return;
+      out.push({
+        x: x + rng.range(-0.1, 0.1),
+        z: z + rng.range(-0.1, 0.1),
+        yaw: Math.atan2(nx, nz) + rng.range(-0.05, 0.05),
+        model: rng.pick(TRAFFIC_CARS),
+      });
+    };
+    if (halfS * 2 >= 3.4) {
+      const rows: number[] = halfS * 2 >= 5.6 ? [-1, 1] : [-1];
+      for (const side of rows) {
+        const b = side * (halfS - 0.5 - CAR_HALF_LEN);
+        for (let a = -halfL + 1.2 + BAY_PITCH / 2; a <= halfL - 1.2; a += BAY_PITCH) {
+          // Nose toward the long edge on this side.
+          place(
+            o.cx + lx * a + sx * b,
+            o.cz + lz * a + sz * b,
+            sx * side,
+            sz * side,
+            CAR_HALF_W + 0.2,
+          );
+        }
+      }
+    } else if (halfS * 2 >= 2.0) {
+      for (let a = -halfL + CAR_HALF_LEN + 0.6; a <= halfL - CAR_HALF_LEN - 0.6; a += 3.4) {
+        place(o.cx + lx * a, o.cz + lz * a, lx, lz, CAR_HALF_W + 0.1);
+      }
+    }
+  }
+  return out;
 }

--- a/games/crazy-waymo/src/world/parcel-mesh.ts
+++ b/games/crazy-waymo/src/world/parcel-mesh.ts
@@ -1,6 +1,6 @@
 import { CHUNK, DRAW_DISTANCE, ROAD_TILE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
 import { Rng } from "../shared/rng";
-import type { ParcelPlan } from "./parcel-plan";
+import { type ParcelLot, type ParcelPlan, pointInRing } from "./parcel-plan";
 import {
   colorsFor,
   GROUND_MIN,
@@ -229,6 +229,23 @@ class GeoBuf {
       this.idx[i + 5] = base + 3;
     }
     this.ni += 6;
+  }
+
+  /** A polygon draped on per-vertex heights, facing up — the surface lots. */
+  capDraped(ring: Float32Array, n: number, ys: Float32Array, lift: number, color: number): void {
+    const tris = earClip(ring, n);
+    this.reserve(n, tris.length);
+    const base = this.nv;
+    for (let i = 0; i < n; i++) {
+      this.vert(ring[i * 2] ?? 0, (ys[i] ?? 0) + lift, ring[i * 2 + 1] ?? 0, 0, 1, 0, color);
+    }
+    for (let t = 0; t < tris.length; t += 3) {
+      const i = this.ni;
+      this.idx[i] = base + (tris[t] ?? 0);
+      this.idx[i + 1] = base + (tris[t + 2] ?? 0);
+      this.idx[i + 2] = base + (tris[t + 1] ?? 0);
+      this.ni += 3;
+    }
   }
 
   /** A horizontal polygon (positive-area xz ring at height y) facing up (+1) or down (-1). */
@@ -1220,6 +1237,7 @@ export async function buildParcelGeometry(
   plans: readonly ParcelPlan[],
   detail: DetailLevel,
   onBreathe?: () => Promise<void>,
+  lots: readonly ParcelLot[] = [],
 ): Promise<ParcelGeometry> {
   const buckets = new Buckets();
   let k = 0;
@@ -1227,7 +1245,77 @@ export async function buildParcelGeometry(
     if (onBreathe && ++k % 400 === 0) await onBreathe();
     buildOne(buckets, p, detail);
   }
+  for (const lot of lots) buildLot(buckets, lot);
   return buckets.flush();
+}
+
+// --- Surface lots ------------------------------------------------------------
+// A surveyed parcel with no building on it: asphalt draped on the ground with
+// bay lines, so a block face reads as parking rather than as a gap. Cars are
+// the build pass's (parcel-build.ts parkOnLots) — they are physics bodies.
+const LOT_ASPHALT = 0x4b5058;
+const LOT_LINE = 0xd6dad6;
+const LOT_LIFT = 0.06;
+const BAY_PITCH = 2.2;
+const BAY_DEPTH = 2.6;
+
+function buildLot(buckets: Buckets, lot: ParcelLot): void {
+  const g = buckets.at("near", lot.obb.cx, lot.obb.cz).wall;
+  g.capDraped(lot.ring, lot.n, lot.ys, LOT_LIFT, LOT_ASPHALT);
+  let lo = Infinity;
+  let hi = -Infinity;
+  let sum = 0;
+  for (let i = 0; i < lot.n; i++) {
+    const y = lot.ys[i] ?? 0;
+    if (y < lo) lo = y;
+    if (y > hi) hi = y;
+    sum += y;
+  }
+  // Bay lines are flat quads; on a lot that falls more than a kerb they would
+  // float or bury, and a sloped lot in SF has no bays painted anyway.
+  if (hi - lo > 1.2) return;
+  const y = sum / lot.n + LOT_LIFT + 0.02;
+  const o = lot.obb;
+  const long = o.halfA >= o.halfB;
+  const lx = long ? o.ex : -o.ez;
+  const lz = long ? o.ez : o.ex;
+  const sx = long ? -o.ez : o.ex;
+  const sz = long ? o.ex : o.ez;
+  const halfL = long ? o.halfA : o.halfB;
+  const halfS = long ? o.halfB : o.halfA;
+  if (halfS * 2 < 3.4) return;
+  const rows: number[] = halfS * 2 >= 5.6 ? [-1, 1] : [halfS > 0 ? -1 : 1];
+  for (const side of rows) {
+    const edge = side * (halfS - 0.5);
+    const inner = side * (halfS - 0.5 - Math.min(BAY_DEPTH, halfS - 0.6));
+    for (let a = -halfL + 1.2; a <= halfL - 1.2; a += BAY_PITCH) {
+      const ax = o.cx + lx * a + sx * edge;
+      const az = o.cz + lz * a + sz * edge;
+      const bx = o.cx + lx * a + sx * inner;
+      const bz = o.cz + lz * a + sz * inner;
+      if (!pointInRing(lot.ring, lot.n, ax, az) || !pointInRing(lot.ring, lot.n, bx, bz)) continue;
+      const wx = lx * 0.05;
+      const wz = lz * 0.05;
+      g.quad(
+        ax - wx,
+        y,
+        az - wz,
+        ax + wx,
+        y,
+        az + wz,
+        bx + wx,
+        y,
+        bz + wz,
+        bx - wx,
+        y,
+        bz - wz,
+        0,
+        1,
+        0,
+        LOT_LINE,
+      );
+    }
+  }
 }
 
 function buildOne(buckets: Buckets, p: ParcelPlan, detail: DetailLevel): void {

--- a/games/crazy-waymo/src/world/parcel-plan.ts
+++ b/games/crazy-waymo/src/world/parcel-plan.ts
@@ -1,6 +1,8 @@
+import polygonClipping from "polygon-clipping";
+
 import { CITY_SEED, ROAD_TILE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
 import type { Solid } from "../shared/types";
-import { nearFreeway } from "./freeways";
+import { freewayPillars, freewaySoffitAt } from "./freeways";
 import { isParkLand } from "./land-class";
 import type { RoadNetwork } from "./network";
 import {
@@ -34,6 +36,23 @@ import type { Terrain } from "./terrain";
 // perpendicular from the centreline, which keeps party walls exactly
 // coincident (both neighbours push the shared vertex to the same point) and
 // keeps L-shapes L-shaped.
+//
+// WHAT STILL CANNOT BE A BUILDING BECOMES A LOT. A ring the clip folds, a
+// group ring that spans a street, a parcel under a viaduct too low for even
+// one storey, a parcel with a pillar in it — each used to leave bare ground,
+// and the kit walk that once filled those gaps no longer runs inside the
+// survey. They are recovered where geometry allows (a folded ring becomes its
+// own box, a street-spanning ring is cut at the street and the larger side
+// kept, a parcel under a deck is built to the storeys that fit) and the rest
+// are emitted as surface parking lots (`lots`), which the mesh pass paints
+// and parks cars on. Nothing in the survey is left as raw ground.
+//
+// The ~500 that still fail the straddle test are MEDIAN parcels: a divided
+// boulevard is two parallel edges in the network, and the game's arcade
+// widths cover the strip between them where the survey has a row of shops.
+// The clip slides such a ring out of one carriageway into the other, the cut
+// leaves nothing, and the road is drawn over the spot — there is no ground to
+// leave bare. `pnpm test` carries them as a baseline, not a defect.
 
 /** Facade to kerb: the sidewalk plus a stoop (city.ts FACADE_MARGIN). */
 const FACADE_MARGIN = 0.45;
@@ -60,6 +79,28 @@ const MERGE_EPS = 0.08;
 const WALL_T = 1.6;
 /** Blocks are ~2 tiles; one dominant colour per block (city.ts BLOCK_SPAN). */
 const BLOCK_SPAN = 26;
+/** A roof has to clear the deck underside by this much. */
+const DECK_CLEAR = 0.5;
+/** A pillar footing this close to a wall is inside the building. */
+const PILLAR_MARGIN = 0.3;
+/**
+ * Where a street CUTS a ring (splitOffStreets) the cut runs at the kerb plus
+ * this, not at the full sidewalk setback: the rings that need cutting are
+ * the ones wedged between two arcade-wide streets, and at the setback the
+ * second street's band swallows what the first one left. A building flush
+ * with the kerb is a thing San Francisco has.
+ */
+const KERB_STRIP = 0.9;
+/** A lot needs this much plan to read as parking rather than a gap. */
+const LOT_MIN_AREA = 6;
+const LOT_MIN_SIDE = 2.2;
+/**
+ * A piece the street cut left is a building only if it is still most of the
+ * ring: a sliver keeps the GROUP's surveyed height, and a 2u-wide piece of a
+ * 17u warehouse outline is a chimney. Below this share the piece is built low.
+ */
+const SPLIT_KEEP_SHARE = 0.4;
+const SPLIT_LOW_STOREYS = 2;
 
 export type Obb = {
   readonly cx: number;
@@ -100,26 +141,48 @@ export type ParcelPlan = {
   readonly solids: readonly Solid[];
 };
 
+/** A surveyed parcel that is a surface lot: asphalt, bay lines, parked cars. */
+export type ParcelLot = {
+  readonly id: number;
+  readonly seed: number;
+  readonly ring: Float32Array;
+  readonly n: number;
+  /** Terrain height under each ring vertex. */
+  readonly ys: Float32Array;
+  readonly obb: Obb;
+  /** Pillar footings standing in the lot — cars keep clear of them. */
+  readonly pillars: readonly { readonly x: number; readonly z: number; readonly half: number }[];
+};
+
 export type ParcelPlanStats = {
   built: number;
   water: number;
   stacked: number;
   reserved: number;
   park: number;
+  /** Under a deck with no room for even one storey, or a pillar in the plan — now a lot. */
   freeway: number;
   /** Rejected after the clip: too small or too thin to be a building. */
   clipped: number;
-  /** The clip folded the ring over itself (a rectangle drawn across a street). */
+  /** The clip folded the ring over itself and the box fallback could not stand either. */
   folded: number;
-  /** A wall still crosses a roadway — the ring spanned a street the clip could not resolve. */
+  /** A wall still crosses a roadway after the street split. */
   straddle: number;
-  /** Centroid still in a lane after the clip. */
+  /** Centroid or a vertex still in a lane after the clip. */
   onRoad: number;
   cliff: number;
   /** Ring vertices the clip moved. */
   movedVerts: number;
   /** Parcels stretched back into the block to keep MIN_DEPTH. */
   stretched: number;
+  /** Built with storeys capped to fit under a viaduct. */
+  underDeck: number;
+  /** Folded rings rebuilt as their own box. */
+  boxed: number;
+  /** Street-spanning rings cut at the street and kept. */
+  split: number;
+  /** Parcels emitted as surface lots. */
+  lots: number;
 };
 
 export type ParcelPlanContext = {
@@ -127,12 +190,21 @@ export type ParcelPlanContext = {
   readonly terrain: Terrain;
   /** "gx,gz" cells no procedural mass may touch (landmarks, depots, editor clears). */
   readonly reserved: ReadonlySet<string>;
+  /**
+   * Height of the ground AS DRAWN (ground.ts makeStandingSurface). Buildings
+   * seat on the raw field and sink their walls to it; a lot is a decal on the
+   * drawn surface and would be buried under the tessellated ground beside
+   * every kerb if it used the field (CLAUDE.md, "nothing sits on the raw
+   * height field").
+   */
+  readonly standAt: (x: number, z: number) => number;
   /** Why a footprint did not become a building — the harness tallies these. */
   readonly onReject?: (id: number, reason: keyof ParcelPlanStats, detail: string) => void;
 };
 
 export type ParcelPlanResult = {
   readonly plans: readonly ParcelPlan[];
+  readonly lots: readonly ParcelLot[];
   readonly stats: ParcelPlanStats;
   /** Grid cells (see cellKey) the SURVEYED parcels cover, dilated one cell — built or not. */
   readonly covered: ReadonlySet<number>;
@@ -164,6 +236,16 @@ function signedArea(ring: Float32Array, n: number): number {
     a += (ring[i * 2] ?? 0) * (ring[j * 2 + 1] ?? 0) - (ring[j * 2] ?? 0) * (ring[i * 2 + 1] ?? 0);
   }
   return a / 2;
+}
+
+function centroidOf(ring: Float32Array, n: number): readonly [number, number] {
+  let cx = 0;
+  let cz = 0;
+  for (let i = 0; i < n; i++) {
+    cx += ring[i * 2] ?? 0;
+    cz += ring[i * 2 + 1] ?? 0;
+  }
+  return [cx / n, cz / n];
 }
 
 function segmentsCross(
@@ -209,6 +291,36 @@ function isSimple(ring: Float32Array, n: number): boolean {
   return true;
 }
 
+export function pointInRing(ring: Float32Array, n: number, x: number, z: number): boolean {
+  let inside = false;
+  for (let i = 0, j = n - 1; i < n; j = i++) {
+    const xi = ring[i * 2] ?? 0;
+    const zi = ring[i * 2 + 1] ?? 0;
+    const xj = ring[j * 2] ?? 0;
+    const zj = ring[j * 2 + 1] ?? 0;
+    if (zi > z !== zj > z && x < ((xj - xi) * (z - zi)) / (zj - zi) + xi) inside = !inside;
+  }
+  return inside;
+}
+
+export function distToRing(ring: Float32Array, n: number, x: number, z: number): number {
+  let best = Infinity;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const ax = ring[i * 2] ?? 0;
+    const az = ring[i * 2 + 1] ?? 0;
+    const bx = ring[j * 2] ?? 0;
+    const bz = ring[j * 2 + 1] ?? 0;
+    const dx = bx - ax;
+    const dz = bz - az;
+    const l2 = dx * dx + dz * dz;
+    const t = l2 > 1e-8 ? Math.min(Math.max(((x - ax) * dx + (z - az) * dz) / l2, 0), 1) : 0;
+    const d = Math.hypot(ax + dx * t - x, az + dz * t - z);
+    if (d < best) best = d;
+  }
+  return best;
+}
+
 function obbOf(ring: Float32Array, n: number, ex: number, ez: number): Obb {
   let minA = Infinity;
   let maxA = -Infinity;
@@ -234,6 +346,49 @@ function obbOf(ring: Float32Array, n: number, ex: number, ez: number): Obb {
     halfA: (maxA - minA) / 2,
     halfB: (maxB - minB) / 2,
   };
+}
+
+/** The OBB as a positive-area 4-ring. */
+function rectRing(o: Obb): Float32Array {
+  const ring = new Float32Array(8);
+  const corners: readonly (readonly [number, number])[] = [
+    [-1, -1],
+    [1, -1],
+    [1, 1],
+    [-1, 1],
+  ];
+  corners.forEach(([a, b], i) => {
+    ring[i * 2] = o.cx + a * o.halfA * o.ex - b * o.halfB * o.ez;
+    ring[i * 2 + 1] = o.cz + a * o.halfA * o.ez + b * o.halfB * o.ex;
+  });
+  if (signedArea(ring, 4) < 0) {
+    const rev = new Float32Array(8);
+    for (let k = 0; k < 4; k++) {
+      rev[k * 2] = ring[(3 - k) * 2] ?? 0;
+      rev[k * 2 + 1] = ring[(3 - k) * 2 + 1] ?? 0;
+    }
+    return rev;
+  }
+  return ring;
+}
+
+/** Frame of the ring's longest edge — the axis a box fallback is laid on. */
+function longestEdgeFrame(ring: Float32Array, n: number): readonly [number, number] {
+  let ex = 1;
+  let ez = 0;
+  let best = 0;
+  for (let i = 0; i < n; i++) {
+    const j = (i + 1) % n;
+    const dx = (ring[j * 2] ?? 0) - (ring[i * 2] ?? 0);
+    const dz = (ring[j * 2 + 1] ?? 0) - (ring[i * 2 + 1] ?? 0);
+    const len = Math.hypot(dx, dz);
+    if (len > best) {
+      best = len;
+      ex = dx / len;
+      ez = dz / len;
+    }
+  }
+  return [ex, ez];
 }
 
 /** One solid per wall for an irregular ring — an AABB over an L walls off a street corner. */
@@ -270,6 +425,10 @@ function obbSolid(o: Obb, shrink: number): Solid {
     maxZ: o.cz + o.halfB * shrink,
     yaw: Math.atan2(-o.ez, o.ex),
   };
+}
+
+function setbackFor(half: number): number {
+  return half + walkFor(half) + FACADE_MARGIN;
 }
 
 /**
@@ -309,13 +468,7 @@ function clipToKerb(
       px = -px;
       pz = -pz;
     }
-    streets.set(hit.edge.id, {
-      ox: hit.x,
-      oz: hit.z,
-      px,
-      pz,
-      setback: hit.edge.half + walkFor(hit.edge.half) + FACADE_MARGIN,
-    });
+    streets.set(hit.edge.id, { ox: hit.x, oz: hit.z, px, pz, setback: setbackFor(hit.edge.half) });
   }
   let moved = 0;
   for (const st of streets.values()) {
@@ -383,8 +536,9 @@ function mergeClose(ring: Float32Array, n: number): number {
   return m;
 }
 
-/** Does any wall run through the drawn asphalt between its two (clear) endpoints? */
-function straddlesStreet(ring: Float32Array, n: number, network: RoadNetwork): boolean {
+/** Ids of the streets whose asphalt a wall runs through between its (clear) endpoints. */
+function straddledStreets(ring: Float32Array, n: number, network: RoadNetwork): number[] {
+  const ids = new Set<number>();
   for (let i = 0; i < n; i++) {
     const j = (i + 1) % n;
     const x0 = ring[i * 2] ?? 0;
@@ -396,14 +550,159 @@ function straddlesStreet(ring: Float32Array, n: number, network: RoadNetwork): b
     for (let k = 1; k < steps; k++) {
       const t = k / steps;
       const hit = network.nearest(x0 + (x1 - x0) * t, z0 + (z1 - z0) * t, ROAD_TILE);
-      if (hit !== null && hit.dist < hit.edge.half - 0.15) return true;
+      if (hit !== null && hit.dist < hit.edge.half - 0.15) ids.add(hit.edge.id);
     }
   }
-  return false;
+  return [...ids];
+}
+
+type PolyRing = [number, number][];
+
+/**
+ * Cut the streets out of a ring and keep the largest piece. A survey ring
+ * that spans a street is a GROUP outline (several buildings the extractor
+ * could not separate); the piece on the far side is another building's, and
+ * this parcel is the one its centroid is nearest.
+ */
+function splitOffStreets(
+  ring: Float32Array,
+  n: number,
+  edgeIds: readonly number[],
+  network: RoadNetwork,
+): Float32Array | null {
+  const strips: PolyRing[][] = [];
+  for (const id of edgeIds) {
+    const edge = network.edges.find((e) => e.id === id);
+    if (!edge) continue;
+    const w = edge.half + KERB_STRIP;
+    const pts = edge.pts;
+    for (let i = 0; i + 3 < pts.length; i += 2) {
+      const ax = pts[i] ?? 0;
+      const az = pts[i + 1] ?? 0;
+      const bx = pts[i + 2] ?? 0;
+      const bz = pts[i + 3] ?? 0;
+      const len = Math.hypot(bx - ax, bz - az);
+      if (len < 1e-3) continue;
+      const tx = (bx - ax) / len;
+      const tz = (bz - az) / len;
+      const nx = -tz;
+      const nz = tx;
+      // Extended by w along the tangent so consecutive quads overlap and the
+      // union has no notch at a bend.
+      const ax2 = ax - tx * w;
+      const az2 = az - tz * w;
+      const bx2 = bx + tx * w;
+      const bz2 = bz + tz * w;
+      strips.push([
+        [
+          [ax2 + nx * w, az2 + nz * w],
+          [bx2 + nx * w, bz2 + nz * w],
+          [bx2 - nx * w, bz2 - nz * w],
+          [ax2 - nx * w, az2 - nz * w],
+          [ax2 + nx * w, az2 + nz * w],
+        ],
+      ]);
+    }
+  }
+  if (strips.length === 0) return null;
+  const outline: PolyRing = [];
+  for (let i = 0; i < n; i++) outline.push([ring[i * 2] ?? 0, ring[i * 2 + 1] ?? 0]);
+  const first = outline[0];
+  if (first) outline.push([first[0], first[1]]);
+  let pieces: PolyRing[][];
+  try {
+    const cut = polygonClipping.union([], ...strips);
+    pieces = polygonClipping.difference([outline], cut);
+  } catch {
+    return null;
+  }
+  let best: PolyRing | null = null;
+  let bestArea = 0;
+  for (const poly of pieces) {
+    const outer = poly[0];
+    if (!outer) continue;
+    let a = 0;
+    for (let i = 0; i + 1 < outer.length; i++) {
+      const p = outer[i];
+      const q = outer[i + 1];
+      if (!p || !q) continue;
+      a += p[0] * q[1] - q[0] * p[1];
+    }
+    a = Math.abs(a) / 2;
+    if (a > bestArea) {
+      bestArea = a;
+      best = outer;
+    }
+  }
+  if (!best || bestArea < MIN_AREA) return null;
+  const m = best.length - 1; // closed ring
+  const out = new Float32Array(m * 2);
+  for (let i = 0; i < m; i++) {
+    const p = best[i];
+    out[i * 2] = p?.[0] ?? 0;
+    out[i * 2 + 1] = p?.[1] ?? 0;
+  }
+  if (signedArea(out, m) < 0) {
+    const rev = new Float32Array(m * 2);
+    for (let k = 0; k < m; k++) {
+      rev[k * 2] = out[(m - 1 - k) * 2] ?? 0;
+      rev[k * 2 + 1] = out[(m - 1 - k) * 2 + 1] ?? 0;
+    }
+    return rev;
+  }
+  return out;
+}
+
+type PillarSpot = { readonly x: number; readonly z: number; readonly half: number };
+
+/** Pillars bucketed on the block lattice, so a parcel asks only its own neighbourhood. */
+class PillarIndex {
+  private readonly cells = new Map<number, PillarSpot[]>();
+  constructor(spots: readonly PillarSpot[]) {
+    for (const p of spots) {
+      const k = cellKey(gridXOf(p.x), gridZOf(p.z));
+      const arr = this.cells.get(k);
+      if (arr) arr.push(p);
+      else this.cells.set(k, [p]);
+    }
+  }
+  /** Pillars whose footing touches the ring. */
+  inside(ring: Float32Array, n: number): PillarSpot[] {
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
+    for (let i = 0; i < n; i++) {
+      const x = ring[i * 2] ?? 0;
+      const z = ring[i * 2 + 1] ?? 0;
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
+    }
+    const out: PillarSpot[] = [];
+    for (let gx = gridXOf(minX) - 1; gx <= gridXOf(maxX) + 1; gx++) {
+      for (let gz = gridZOf(minZ) - 1; gz <= gridZOf(maxZ) + 1; gz++) {
+        for (const p of this.cells.get(cellKey(gx, gz)) ?? []) {
+          const reach = p.half + PILLAR_MARGIN;
+          if (
+            p.x < minX - reach ||
+            p.x > maxX + reach ||
+            p.z < minZ - reach ||
+            p.z > maxZ + reach
+          ) {
+            continue;
+          }
+          if (pointInRing(ring, n, p.x, p.z) || distToRing(ring, n, p.x, p.z) < reach) out.push(p);
+        }
+      }
+    }
+    return out;
+  }
 }
 
 export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
-  const { network, terrain, reserved } = ctx;
+  const { network, terrain, reserved, standAt } = ctx;
   const stats: ParcelPlanStats = {
     built: 0,
     water: 0,
@@ -418,12 +717,50 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
     cliff: 0,
     movedVerts: 0,
     stretched: 0,
+    underDeck: 0,
+    boxed: 0,
+    split: 0,
+    lots: 0,
   };
   const plans: ParcelPlan[] = [];
+  const lots: ParcelLot[] = [];
   const covered = new Set<number>();
+  const pillars = new PillarIndex(freewayPillars(terrain, network));
   const onAsphalt = (x: number, z: number, margin: number): boolean => {
     const hit = network.nearest(x, z, ROAD_TILE * 1.4);
     return hit !== null && hit.dist < hit.edge.half + margin;
+  };
+  const anyVertexInLane = (ring: Float32Array, n: number): boolean => {
+    for (let i = 0; i < n; i++) {
+      if (onAsphalt(ring[i * 2] ?? 0, ring[i * 2 + 1] ?? 0, -0.45)) return true;
+    }
+    return false;
+  };
+  const soffitOver = (ring: Float32Array, n: number, cx: number, cz: number): number | null => {
+    let soffit = freewaySoffitAt(terrain, network, cx, cz, 0.5);
+    for (let i = 0; i < n; i++) {
+      const s = freewaySoffitAt(terrain, network, ring[i * 2] ?? 0, ring[i * 2 + 1] ?? 0, 0.3);
+      if (s !== null && (soffit === null || s < soffit)) soffit = s;
+    }
+    return soffit;
+  };
+  /** A parcel that cannot be a building but can be a lot: paint + cars. */
+  const emitLot = (
+    id: number,
+    seed: number,
+    ring: Float32Array,
+    n: number,
+    obb: Obb,
+    spots: readonly PillarSpot[],
+  ): boolean => {
+    if (Math.min(obb.halfA, obb.halfB) * 2 < LOT_MIN_SIDE || signedArea(ring, n) < LOT_MIN_AREA) {
+      return false;
+    }
+    const ys = new Float32Array(n);
+    for (let i = 0; i < n; i++) ys[i] = standAt(ring[i * 2] ?? 0, ring[i * 2 + 1] ?? 0);
+    lots.push({ id, seed, ring, n, ys, obb, pillars: spots });
+    stats.lots++;
+    return true;
   };
 
   for (let id = 0; id < SF_FOOTPRINTS.length; id++) {
@@ -440,7 +777,7 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
     // Orient positive (interior to the left of each edge) — party-wall edge
     // indices follow the reversal.
     let n = n0;
-    let ring = new Float32Array(n * 2);
+    let ring: Float32Array = new Float32Array(n * 2);
     let blind = new Uint8Array(n);
     for (let i = 0; i < n; i++) {
       ring[i * 2] = flat[1 + i * 2] ?? 0;
@@ -458,14 +795,8 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
       for (const e of adjacency.blind) blind[e] = 1;
     }
     const original = Float32Array.from(ring);
-    let cx = 0;
-    let cz = 0;
-    for (let i = 0; i < n; i++) {
-      cx += ring[i * 2] ?? 0;
-      cz += ring[i * 2 + 1] ?? 0;
-    }
-    cx /= n;
-    cz /= n;
+    const area0 = signedArea(ring, n);
+    let [cx, cz] = centroidOf(ring, n);
     const gx = gridXOf(cx);
     const gz = gridZOf(cz);
     if (!isLandCell(gx, gz)) {
@@ -474,8 +805,7 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
     }
     // Coverage is the SOURCE data's footprint, not the built one: a block the
     // survey mapped is this fabric's to fill, and a parcel it then rejects
-    // (a freeway corridor, a ring across a street) leaves a lot, not a kit
-    // house in the middle of a real terrace.
+    // leaves a lot, not a kit house in the middle of a real terrace.
     for (let i = 0; i < n; i++) {
       const vgx = gridXOf(ring[i * 2] ?? 0);
       const vgz = gridZOf(ring[i * 2 + 1] ?? 0);
@@ -499,48 +829,75 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
       stats.park++;
       continue;
     }
-    let fwHit = nearFreeway(cx, cz, 0.5);
-    for (let i = 0; i < n && !fwHit; i++) {
-      if (nearFreeway(ring[i * 2] ?? 0, ring[i * 2 + 1] ?? 0, 0.3)) fwHit = true;
-    }
-    if (fwHit) {
-      stats.freeway++;
-      continue;
-    }
 
     // --- The kerb clip ---
     let movedAny = false;
-    for (let iter = 0; iter < 3; iter++) {
-      const moved = clipToKerb(ring, n, network, cx, cz);
-      stats.movedVerts += moved;
-      if (moved === 0) break;
-      movedAny = true;
+    const clip = (): void => {
+      for (let iter = 0; iter < 3; iter++) {
+        const moved = clipToKerb(ring, n, network, cx, cz);
+        stats.movedVerts += moved;
+        if (moved === 0) break;
+        movedAny = true;
+      }
+      if (movedAny) {
+        // Stacked vertices change the ring's vertex count; the party-wall
+        // edge indices only survive if nothing merged, so a merge drops them
+        // (the walls are still coincident — only the window rule loses them).
+        const m = mergeClose(ring, n);
+        if (m !== n) {
+          n = m;
+          ring = ring.slice(0, n * 2);
+          blind = new Uint8Array(n);
+        }
+      }
+    };
+    clip();
+    if (n < 3) {
+      stats.clipped++;
+      ctx.onReject?.(id, "clipped", "n<3");
+      continue;
     }
-    if (movedAny) {
-      // Stacked vertices change the ring's vertex count; the party-wall edge
-      // indices only survive if nothing merged, so a merge drops them (the
-      // walls are still coincident — only the window rule loses them).
-      const m = mergeClose(ring, n);
-      if (m !== n) {
-        n = m;
-        ring = ring.slice(0, n * 2);
-        blind = new Uint8Array(n);
+    // --- Recovery: a folded ring becomes its box; a ring across a street is
+    // cut there and the larger side kept. Each recovery re-runs the tests
+    // that the previous shape failed.
+    let boxed = false;
+    let split = false;
+    if (!isSimple(ring, n)) {
+      const [ex, ez] = longestEdgeFrame(ring, n);
+      ring = rectRing(obbOf(ring, n, ex, ez));
+      n = 4;
+      blind = new Uint8Array(4);
+      boxed = true;
+    }
+    let crossing = straddledStreets(ring, n, network);
+    for (let round = 0; crossing.length > 0 && round < 4; round++) {
+      const piece = splitOffStreets(ring, n, crossing, network);
+      if (piece === null) break;
+      ring = piece;
+      n = piece.length / 2;
+      blind = new Uint8Array(n);
+      [cx, cz] = centroidOf(ring, n);
+      split = true;
+      // No re-clip: the clip would slide the piece back into the band it was
+      // just cut out of. The piece is clear of asphalt by construction.
+      if (n >= 3 && !isSimple(ring, n)) {
+        const [ex, ez] = longestEdgeFrame(ring, n);
+        ring = rectRing(obbOf(ring, n, ex, ez));
+        n = 4;
+        blind = new Uint8Array(4);
+        boxed = true;
       }
-      if (n < 3) {
-        stats.clipped++;
-        ctx.onReject?.(id, "clipped", "n<3");
-        continue;
-      }
-      if (!isSimple(ring, n)) {
-        stats.folded++;
-        ctx.onReject?.(id, "folded", `n=${n} n0=${n0}`);
-        continue;
-      }
-      if (straddlesStreet(ring, n, network)) {
-        stats.straddle++;
-        ctx.onReject?.(id, "straddle", `n=${n}`);
-        continue;
-      }
+      crossing = n >= 3 ? straddledStreets(ring, n, network) : [];
+    }
+    if (crossing.length > 0) {
+      stats.straddle++;
+      ctx.onReject?.(id, "straddle", `n=${n} split=${split} boxed=${boxed}`);
+      continue;
+    }
+    if (n < 3) {
+      stats.clipped++;
+      ctx.onReject?.(id, "clipped", "n<3 after split");
+      continue;
     }
     let area = signedArea(ring, n);
     if (area < 0.05) {
@@ -548,28 +905,13 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
       ctx.onReject?.(id, "clipped", `area=${area.toFixed(2)} moved=${movedAny}`);
       continue;
     }
-    cx = 0;
-    cz = 0;
-    for (let i = 0; i < n; i++) {
-      cx += ring[i * 2] ?? 0;
-      cz += ring[i * 2 + 1] ?? 0;
-    }
-    cx /= n;
-    cz /= n;
-    if (onAsphalt(cx, cz, 0.4)) {
+    [cx, cz] = centroidOf(ring, n);
+    if (onAsphalt(cx, cz, 0.4) || anyVertexInLane(ring, n)) {
+      // The clip works one street at a time; a vertex it moved clear of a
+      // minor street can land inside the boulevard that street joins.
+      // Nothing here is allowed to stand in a lane.
       stats.onRoad++;
-      continue;
-    }
-    // The clip works one street at a time; a vertex it moved clear of a minor
-    // street can land inside the boulevard that street joins. Nothing here is
-    // allowed to stand in a lane, so the last word is a plain test of every
-    // vertex against the drawn asphalt.
-    let vertInLane = false;
-    for (let i = 0; i < n && !vertInLane; i++) {
-      if (onAsphalt(ring[i * 2] ?? 0, ring[i * 2 + 1] ?? 0, -0.45)) vertInLane = true;
-    }
-    if (vertInLane) {
-      stats.onRoad++;
+      ctx.onReject?.(id, "onRoad", `boxed=${boxed} split=${split}`);
       continue;
     }
 
@@ -679,12 +1021,31 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
     const seatY = fall > 1.0 ? Math.max(loY + fall * STEP_INTO_SLOPE, hiY - STEP_BURY_MAX) : hiY;
     const footY = loY - 0.35;
 
-    // --- Kind, storeys, rhythm ---
+    // --- Storeys, capped under a viaduct; kind; rhythm ---
     const district = districtAt(gx, gz);
     const character: FabricChar =
       district.character === "park" ? "residential" : district.character;
     const seed = hash32(id * 2654435761 + CITY_SEED);
-    const storeys = storeysOf(realH);
+    let storeys = storeysOf(realH);
+    if (split && area < area0 * SPLIT_KEEP_SHARE) storeys = Math.min(storeys, SPLIT_LOW_STOREYS);
+    const soffit = soffitOver(ring, n, cx, cz);
+    const pillarHits = pillars.inside(ring, n);
+    if (soffit !== null) {
+      // Build what fits under the deck — SF's freeways run over two- and
+      // three-storey fabric for most of their length — and a parcel with no
+      // room for one storey, or a footing in its plan, is a lot.
+      while (storeys > 1 && seatY + visualHeight(storeys) > soffit - DECK_CLEAR) storeys--;
+      if (seatY + visualHeight(storeys) > soffit - DECK_CLEAR || pillarHits.length > 0) {
+        stats.freeway++;
+        emitLot(id, seed, ring, n, obb, pillarHits);
+        continue;
+      }
+      stats.underDeck++;
+    } else if (pillarHits.length > 0) {
+      stats.freeway++;
+      emitLot(id, seed, ring, n, obb, pillarHits);
+      continue;
+    }
     const kind = resolveKind({
       character,
       district: district.name,
@@ -725,8 +1086,10 @@ export function planParcels(ctx: ParcelPlanContext): ParcelPlanResult {
       solids,
     });
     stats.built++;
+    if (boxed) stats.boxed++;
+    if (split) stats.split++;
   }
-  return { plans, stats, covered };
+  return { plans, lots, stats, covered };
 }
 
 /** The front edge's endpoints, for the facade stamp furniture dresses. */

--- a/games/crazy-waymo/tools/test-world.mts
+++ b/games/crazy-waymo/tools/test-world.mts
@@ -732,10 +732,11 @@ console.log(`  (plan + network in ${Math.round(performance.now() - t0)}ms)`);
 {
   const prot = landmarkProtection(plan, network);
   const terrain = makeTerrain();
+  const { standAt } = buildAuditWorld();
   const t0 = performance.now();
-  const parcels = planParcels({ network, terrain, reserved: prot.reserved });
+  const parcels = planParcels({ network, terrain, reserved: prot.reserved, standAt });
   const planMs = Math.round(performance.now() - t0);
-  const again = planParcels({ network, terrain, reserved: prot.reserved });
+  const again = planParcels({ network, terrain, reserved: prot.reserved, standAt });
   const sig = (r: typeof parcels): string =>
     r.plans
       .map(
@@ -751,10 +752,10 @@ console.log(`  (plan + network in ${Math.round(performance.now() - t0)}ms)`);
   // The old kit pass built 2,890 of these; the kerb clip is what lifts it.
   check(
     "real parcels build instead of being rejected",
-    s.built >= 15000 && s.onRoad + s.clipped <= 3000,
+    s.built >= 16500 && s.onRoad + s.clipped <= 3000 && s.straddle <= 600,
     `${s.built} of ${SF_FOOTPRINTS.length} built (${s.onRoad} in a lane, ${s.clipped} clipped away, ` +
       `${s.folded} folded, ${s.straddle} straddling, ${s.stacked} stacked, ${s.park} park, ` +
-      `${s.reserved} reserved, ${s.freeway} freeway, ${s.cliff} cliff, ${s.stretched} stretched)`,
+      `${s.reserved} reserved, ${s.freeway} freeway, ${s.cliff} cliff, ${s.stretched} stretched; ${s.underDeck} under a deck, ${s.boxed} boxed, ${s.split} split)`,
   );
   // Every wall vertex clears the drawn asphalt — that is what the clip is for.
   let pastKerb = 0;
@@ -787,6 +788,13 @@ console.log(`  (plan + network in ${Math.round(performance.now() - t0)}ms)`);
     inRoad.length <= 250 && deep.length === 0,
     `${boxes.length} solids, ${inRoad.length} past the kerb, ${deep.length} over 3u deep` +
       (deep[0] ? `, worst ${deep[0].depth.toFixed(1)}u @ ${uv(deep[0].x, deep[0].z)}` : ""),
+  );
+  // What the plan cannot build it hands over as a surface lot, so the survey
+  // never leaves bare ground (the kit walk no longer fills inside it).
+  check(
+    "unbuildable parcels become lots, not bare ground",
+    parcels.lots.length >= 60 && parcels.lots.length <= 2500,
+    `${parcels.lots.length} lots`,
   );
   const kinds = new Map<string, number>();
   for (const p of parcels.plans) kinds.set(p.kind, (kinds.get(p.kind) ?? 0) + 1);


### PR DESCRIPTION
## What

The parcel plan no longer drops what the kerb clip cannot place cleanly:

- **Freeway corridor** — a parcel under a viaduct is built to the storeys that clear the deck underside (`freewaySoffitAt`, deck samples bucketed on a 60u hash). A pillar in the plan, or no room for even one storey, makes it a surface lot instead.
- **Folded rings** — rebuilt as their own OBB box.
- **Street-spanning rings** — cut at the kerb with polygon-clipping, larger side kept, iterated while anything still crosses. A cut sliver keeps two storeys rather than its group's surveyed height.
- **Surface lots** (`ParcelLot`) — draped asphalt seated on the standing surface, bay lines, nose-in cars that keep clear of the ring, the pillars and every building. Cars join `parkedCarSpecs` on both load paths.

| | before | after |
|---|---|---|
| Built | 15,872 | 16,632 |
| Under a deck | 0 | 242 |
| Boxed / split | 0 / 0 | 278 / 264 |
| Lots | 0 | 84 (262 cars) |
| Plan time | 0.95 s | 1.4 s |

The ~520 still rejected are median parcels: the survey ring sits between the two parallel edges of a divided boulevard and the game's arcade widths cover it. The road is drawn over them; `pnpm test` carries them as a baseline.

## Verified

Same-camera A/B at the SoMa viaduct chase spot and aerial (buildings now on both flanks and along the curve), lot close-ups in Hayes Valley and SoMa. `pnpm test` 41/41; typecheck, lint, format clean. Runtime only — no rebake.

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers the surveyed parcels the kerb clip used to drop, so no parcel in the plan is left as bare ground.

- Parcels under a freeway deck build to the storeys that clear the deck underside (`freewaySoffitAt`); a pillar in the plan, or no room for one storey, makes it a surface lot.
- Folded rings are rebuilt as their own OBB box; street-spanning rings are cut at the kerb with `polygon-clipping` and the larger side kept, iterated while anything still crosses.
- Cut slivers keep two storeys rather than the group's surveyed height.
- Surface lots get draped asphalt, bay lines, and nose-in cars that avoid the ring, pillars, and every building; cars join `parkedCarSpecs` on both load paths.
- Built parcels go from 15,872 to 16,632; the ~520 still rejected are median strips between divided-boulevard edges that the road draws over. Plan time goes 0.95s → 1.4s.
- Runtime only — no rebake.

Closes #305.

<sup>Written for commit 16e2940f3e6c091eb984363f8d7cd2770cfed965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

