### PR TITLE
crazy-waymo: parcel fabric polish — podium shops, matte glass, block trim

### DIFF
--- a/games/crazy-waymo/src/world/parcel-build.ts
+++ b/games/crazy-waymo/src/world/parcel-build.ts
@@ -38,8 +38,8 @@ applyMaterialBreakup(WALL, CITY_BREAKUP);
 const GLASS_DARK = new THREE.MeshStandardMaterial({
   color: 0xffffff,
   vertexColors: true,
-  roughness: 0.32,
-  metalness: 0.25,
+  roughness: 0.78,
+  metalness: 0,
 });
 GLASS_DARK.name = "parcel-glass";
 
@@ -49,8 +49,8 @@ GLASS_DARK.name = "parcel-glass";
 const GLASS_LIT = new THREE.MeshStandardMaterial({
   color: 0xffffff,
   vertexColors: true,
-  roughness: 0.32,
-  metalness: 0.25,
+  roughness: 0.78,
+  metalness: 0,
   emissive: new THREE.Color(0xffc978),
   emissiveIntensity: 0,
 });

--- a/games/crazy-waymo/src/world/parcel-mesh.ts
+++ b/games/crazy-waymo/src/world/parcel-mesh.ts
@@ -496,6 +496,7 @@ function ledge(
 
 /** The chase camera's eye height: a ledge above it shows its underside. */
 const EYE_H = 6.5;
+const STOOP_RAIL = 0x2e3134;
 
 type Storeys = {
   readonly groundH: number;
@@ -725,6 +726,46 @@ function bay(c: Ctx, w: Wall, ac: number, bw: number, colors: ParcelColors): voi
   g.quad(flx, y0, flz, frx, y0, frz, frx, y1, frz, flx, y1, flz, w.nx, 0, w.nz, bodyCol);
   g.quad(frx, y0, frz, wrx, y0, wrz, wrx, y1, wrz, frx, y1, frz, rn.x, 0, rn.z, bodyCol);
   g.quad(wlx, y1, wlz, flx, y1, flz, frx, y1, frz, wrx, y1, wrz, 0, 1, 0, colors.trim);
+  // The bracketed base the bay stands on, and the cap it wears: a skirt
+  // under the footprint (sides only — its underside faces the stoop) and a
+  // lip proud of the top ribbon, two-sided so the chase cam sees it from the
+  // street. These are what separate a bay from a box glued to a wall.
+  {
+    const bcx = w.x0 + w.tx * ac + w.nx * (d / 2);
+    const bcz = w.z0 + w.tz * ac + w.nz * (d / 2);
+    box(g, bcx, bcz, w.tx, w.tz, bw / 2 + d * 0.7, d / 2 + 0.04, y0 - 0.32, y0, colors.trim, {
+      sides: true,
+    });
+    const o = 0.12;
+    const yl = y1 + 0.02;
+    const lx0 = wlx - w.tx * o;
+    const lz0 = wlz - w.tz * o;
+    const lx1 = flx + w.nx * o - w.tx * o;
+    const lz1 = flz + w.nz * o - w.tz * o;
+    const lx2 = frx + w.nx * o + w.tx * o;
+    const lz2 = frz + w.nz * o + w.tz * o;
+    const lx3 = wrx + w.tx * o;
+    const lz3 = wrz + w.tz * o;
+    g.quad(lx0, yl, lz0, lx1, yl, lz1, lx2, yl, lz2, lx3, yl, lz3, 0, 1, 0, colors.trim);
+    g.quad(
+      lx0,
+      yl - 0.06,
+      lz0,
+      lx1,
+      yl - 0.06,
+      lz1,
+      lx2,
+      yl - 0.06,
+      lz2,
+      lx3,
+      yl - 0.06,
+      lz3,
+      0,
+      -1,
+      0,
+      colors.trim,
+    );
+  }
   // Trim edge along the top of the bay, the ribbon a painted lady wears.
   g.quad(
     wlx,
@@ -869,6 +910,18 @@ function groundResidential(
     OFF2,
     shade(colors.garage, 0.8),
   );
+  if (c.detail >= 2) {
+    decal(
+      b.wall,
+      w,
+      a + 0.06,
+      garageW - 0.12,
+      y0 + garageH * 0.74,
+      0.05,
+      OFF2,
+      shade(colors.garage, 0.8),
+    );
+  }
   const da = a + garageW + gap;
   decal(b.wall, w, da, doorW, y0, doorH, OFF, colors.door);
   decal(b.wall, w, da - 0.05, doorW + 0.1, y0 + doorH, 0.1, OFF, colors.trim);
@@ -882,6 +935,10 @@ function groundResidential(
       top: true,
       sides: true,
     });
+    // Iron rail up the garage side of the stoop.
+    const rx = w.x0 + w.tx * (da - 0.04) + w.nx * 0.28;
+    const rz = w.z0 + w.tz * (da - 0.04) + w.nz * 0.28;
+    box(b.wall, rx, rz, w.tx, w.tz, 0.025, 0.26, y0 + 0.22, y0 + 0.92, STOOP_RAIL, { sides: true });
   }
 }
 
@@ -1047,6 +1104,56 @@ function buildRowhouse(c: Ctx, stucco: boolean): void {
       if (!w.blind && st.count >= 2) cornice(c, w, false);
     }
   }
+  roofClutter(c);
+}
+
+/** A skylight and the odd vent on a residential roof — the aerial reads the roof plane first. */
+function roofClutter(c: Ctx): void {
+  if (c.detail < 2) return;
+  const { p, rng } = c;
+  const col = c.colors[0];
+  if (col === undefined) return;
+  const o = p.obb;
+  if (o.halfA < 1.4 || o.halfB < 1.4) return;
+  const g = c.detailAt(o.cx, o.cz).wall;
+  const capY = c.topY - PARAPET;
+  const spot = (fa: number, fb: number): readonly [number, number] => [
+    o.cx + fa * o.halfA * o.ex - fb * o.halfB * o.ez,
+    o.cz + fa * o.halfA * o.ez + fb * o.halfB * o.ex,
+  ];
+  if (rng.chance(0.55)) {
+    const [sx, sz] = spot(rng.range(-0.45, 0.45), rng.range(-0.45, 0.45));
+    const hw = 0.45;
+    const hd = 0.3;
+    const y = capY + 0.03;
+    const ax = o.ex * hw;
+    const az = o.ez * hw;
+    const bx = -o.ez * hd;
+    const bz = o.ex * hd;
+    g.quad(
+      sx - ax - bx,
+      y,
+      sz - az - bz,
+      sx + ax - bx,
+      y,
+      sz + az - bz,
+      sx + ax + bx,
+      y,
+      sz + az + bz,
+      sx - ax + bx,
+      y,
+      sz - az + bz,
+      0,
+      1,
+      0,
+      col.glass,
+    );
+  }
+  if (rng.chance(0.3)) {
+    const [vx, vz] = spot(rng.range(-0.5, 0.5), rng.range(-0.5, 0.5));
+    const sz = rng.range(0.2, 0.3);
+    box(g, vx, vz, o.ex, o.ez, sz, sz, capY, capY + sz * 2.2, 0xb9bcbf, { top: true, sides: true });
+  }
 }
 
 function buildMidrise(c: Ctx): void {
@@ -1071,8 +1178,26 @@ function buildMidrise(c: Ctx): void {
   roofPlant(c, rng.chance(0.5) ? 2 : 1, rng.chance(0.55));
 }
 
+/**
+ * A tower's ground floor is shops, not a lobby band: SF keeps retail under
+ * its glass, and a street of blank podiums is what made downtown read as a
+ * model. Blind and short faces keep the strip.
+ */
+function podiumShops(c: Ctx, w: Wall): void {
+  const { p, st } = c;
+  const col = c.colors[0];
+  if (col === undefined) return;
+  if (w.blind || w.len < 3.2 || c.detail < 1) {
+    windowStrips(c, w, 0, 1, p.seatY + 0.1, st.groundH - 0.2, 0.4);
+    return;
+  }
+  const units = Math.max(1, Math.round(w.len / 4.5));
+  const unitW = w.len / units;
+  for (let u = 0; u < units; u++) storefront(c, w, u * unitW, unitW, col, c.rng.chance(0.6));
+}
+
 function buildTower(c: Ctx): void {
-  const { p, st, rng } = c;
+  const { p, st } = c;
   const col = c.colors[0];
   if (col === undefined) return;
   const o = p.obb;
@@ -1086,7 +1211,7 @@ function buildTower(c: Ctx): void {
     const podium: Ctx = { ...c, topY: podiumTop };
     body(podium);
     for (const w of c.walls) {
-      windowStrips(podium, w, 0, 1, p.seatY + 0.1, st.groundH - 0.2, 0.4);
+      podiumShops(podium, w);
       windowGrid(podium, w, 1.15, 0.6, 0);
       cornice(podium, w, false);
     }
@@ -1125,13 +1250,12 @@ function buildTower(c: Ctx): void {
   } else {
     body(c);
     for (const w of c.walls) {
-      windowStrips(c, w, 0, 1, p.seatY + 0.1, st.groundH - 0.2, 0.4);
+      podiumShops(c, w);
       windowStrips(c, w, 1, st.count, p.seatY + st.groundH, st.upperH);
     }
     crown(c, p.ring, o, 1);
   }
   roofPlant(c, 1, false);
-  void rng;
 }
 
 function crown(

--- a/games/crazy-waymo/src/world/parcel-style.ts
+++ b/games/crazy-waymo/src/world/parcel-style.ts
@@ -198,18 +198,35 @@ export function mix(a: number, b: number, t: number): number {
 }
 
 const WHITE_TRIM = 0xf3efe6;
+const CREAM_TRIM = 0xf1e3c8;
 const GLASS_DAY = 0x34424f;
-const GLASS_TOWER = 0x6d8ba3;
+// Matte and a step darker than any tower body (parcel-build.ts glass is
+// roughness 0.78, metalness 0): the strips read as a darker band on the
+// shaft, the kart-racer read, instead of a lighter one catching the sky.
+const GLASS_TOWER = 0x45586a;
 const GLASS_SHOP = 0x2a3644;
+/**
+ * Trim per district, chosen per BLOCK: SF trim is not always white. The
+ * painted ladies wear dark green, near-black or cream against the body as
+ * often as white; the avenues' stucco takes cream; everything else takes a
+ * value step off its own body.
+ */
+const VICTORIAN_TRIMS: readonly number[] = [WHITE_TRIM, WHITE_TRIM, 0x2f3a36, 0x2b2b2b, CREAM_TRIM];
+const STUCCO_TRIMS: readonly number[] = [WHITE_TRIM, CREAM_TRIM, WHITE_TRIM];
 
 /** Perceived lightness 0..1. */
 function luma(c: number): number {
   return (0.299 * channel(c, 16) + 0.587 * channel(c, 8) + 0.114 * channel(c, 0)) / 255;
 }
 
-/** White trim on a coloured body; on a body already near white, a darker step so the frames still read. */
-function trimFor(body: number): number {
-  return luma(body) > 0.86 ? shade(body, 0.74) : WHITE_TRIM;
+/** The block's trim, unless the body is so pale the trim would vanish on it. */
+function trimFor(body: number, character: FabricChar, blockHash: number): number {
+  const pick =
+    character === "victorian"
+      ? VICTORIAN_TRIMS[(blockHash >> 9) % VICTORIAN_TRIMS.length]
+      : STUCCO_TRIMS[(blockHash >> 9) % STUCCO_TRIMS.length];
+  const trim = pick ?? WHITE_TRIM;
+  return Math.abs(luma(body) - luma(trim)) < 0.14 ? shade(body, 0.74) : trim;
 }
 
 export function colorsFor(
@@ -231,18 +248,21 @@ export function colorsFor(
     (character === "residential" || character === "victorian" || character === "commercial")
       ? (ROOF_ACCENTS[(blockHash >> 11) % ROOF_ACCENTS.length] ?? 0xb5654a)
       : (roofs[(blockHash >> 3) % roofs.length] ?? 0x9a9386);
-  const awning =
-    AWNING_COLORS[(blockHash + Math.floor(unitRoll * 5)) % AWNING_COLORS.length] ?? 0xc8433a;
+  // ONE accent per block for doors and awnings — a street reads as a set
+  // when its shops share a sign colour, and as a paint chart when they don't.
+  const awning = AWNING_COLORS[(blockHash >> 5) % AWNING_COLORS.length] ?? 0xc8433a;
   switch (kind) {
     case "rowhouse":
     case "stucco":
       return {
         body,
-        trim: trimFor(body),
+        trim: trimFor(body, character, blockHash),
         base: shade(body, 0.72),
         roof,
         glass: GLASS_DAY,
-        door: shade(mix(body, 0x3a2f2a, 0.7), 0.9),
+        // A painted front door in the block's accent — the Victorian's one
+        // saturated note; the stucco box keeps a plain dark door.
+        door: kind === "rowhouse" ? shade(awning, 0.85) : shade(mix(body, 0x3a2f2a, 0.7), 0.9),
         garage: mix(body, 0x8a8d90, 0.75),
         awning,
       };
@@ -262,10 +282,10 @@ export function colorsFor(
       const tb = glassTower ? mix(GLASS_TOWER, body, 0.35) : body;
       return {
         body: tb,
-        trim: glassTower ? shade(tb, 1.25) : shade(body, 0.82),
+        trim: glassTower ? shade(tb, 1.18) : shade(body, 0.82),
         base: shade(tb, 0.72),
         roof,
-        glass: glassTower ? shade(GLASS_TOWER, 0.8) : GLASS_DAY,
+        glass: glassTower ? GLASS_TOWER : GLASS_DAY,
         door: 0x2f3438,
         garage: 0x6b6f73,
         awning,


### PR DESCRIPTION
## What

- **Tower podium shops** — every open face of a tower's ground floor gets shopfronts (glass, mullions, sign band, awnings) instead of a lobby strip; blind and short faces keep the strip.
- **Matte glass** — roughness 0.78, metalness 0, `GLASS_TOWER` a step darker: the strips read as a darker band on the shaft, not a lighter one catching the sky.
- **Trim per district, per block** — Victorians in white / dark green / near-black / cream, stucco in white / cream, a value step when the body is too close to the trim. One awning accent per block, and the Victorian front door painted in it.
- **Bays** get a bracketed skirt and an overhanging two-sided cap lip; **garages** a second panel line; **stoops** an iron rail; **residential roofs** a skylight and the odd vent. Detail tier only.

Desktop 3.9M → 4.2M verts (budget 4.5M), phone tier unchanged. Runtime only — no rebake.

## Verified

Same-camera pairs at Union Square (podium shops, glass value), Nob Hill (trim, doors, bay skirts and lips), Chinatown and FiDi aerials, Richmond aerial (roof clutter). `pnpm test` 41/41.

While A/B-ing I chased a blocky dither band on a Nob Hill party wall; bisecting each new feature off and finally pinning the perf tier on `main` showed it is the shadow-map terminator on that wall and moves run to run with the shadow camera fit. Pre-existing, not from this change.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the parcel fabric so tower podiums read as retail streets (open faces get shopfronts; blind and short faces keep the lobby strip), glass reads as a darker matte band, and trim varies per district — Victorians in white, dark green, near-black, or cream; stucco in white or cream — with one awning accent per block and the Victorian door painted in it. Runtime only — desktop verts go from 3.9M to 4.2M (budget 4.5M); the phone tier is unchanged.

**Detail tier geometry**
- Bays get a bracketed skirt and an overhanging two-sided cap lip.
- Garages get a second panel line; stoops get an iron rail.
- Residential roofs get a skylight and the odd vent.

**Verified**
- Same-camera pairs at Union Square, Nob Hill, Chinatown, FiDi, and Richmond aerials.
- `pnpm test` passes 41/41.
- The dither band on a Nob Hill party wall is a pre-existing shadow-map terminator artifact, not from this change.

<sup>Written for commit 3a68d500b5a20a947558522ca06c90253d7d890c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

