### PR TITLE
crazy-waymo: stream the parcel fabric around the camera

### DIFF
--- a/games/crazy-waymo/CLAUDE.md
+++ b/games/crazy-waymo/CLAUDE.md
@@ -138,9 +138,14 @@ bake-parcels.mts` writes it): ~147k footprints — the licensed downtown survey
   gone (`public/models/buildings` holds only the depot). Every building is a
   parcel; ground the source does not cover stays green. Below the full detail
   tier (phones: `parcelDetailLevel`) the survey parcels' flanks and rears also
-  go on the facade shader, so a phone still sees windows everywhere. What the
-  phone does NOT get yet is a smaller upload: the lean fabric is ~30 B/vertex
-  and the whole city is resident (see the harness's "MB on the GPU"). Rejection is
+  go on the facade shader, so a phone still sees windows everywhere. The
+  fabric STREAMS (`parcel-stream.ts`): the ~260 skyline parcels (≥ 13u) are
+  built once, everything else lives in 80u cells generated one per frame as
+  they come within the fog line + 60u of the camera and freed 180u past it —
+  ~95 MB resident at FiDi on desktop, ~50 MB at the phone radius, against
+  240 MB for the whole city. `city.parcelStreamStats()` (reachable as
+  `__taxi.game.city.parcelStreamStats()`) reports residency; `pnpm test`
+  budgets it at the densest probe. Rejection is
   the last resort: a folded ring is rebuilt as its own box, a ring that spans
   a street is cut at the kerb and the larger side kept, a parcel under a
   viaduct is built to the storeys that clear the soffit (`freewaySoffitAt`),

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -50,7 +50,8 @@ import type { CityGenPayload } from "./gen-worker";
 import { buildFreeways, nearFreeway } from "./freeways";
 import { buildPiers } from "./piers";
 import { buildLandmarks, landmarkProtection } from "./landmarks";
-import { buildParcelFabric, parcelDetailLevel } from "./parcel-build";
+import { buildParcelFabric, parcelDetailLevel, parkOnLots } from "./parcel-build";
+import { ParcelStreamer, type ParcelStreamStats, streamRadiusFor } from "./parcel-stream";
 import { frontSegment, type ParcelPlanResult, emptyParcelPlan, planParcels } from "./parcel-plan";
 import type { ParcelSource } from "./parcel-source";
 import { districtAt, makeTerrain } from "./sf-map";
@@ -1083,25 +1084,37 @@ export class CityModel {
     }
     return this.parcelPlanCache;
   }
+  // The skyline (parcel-stream.ts explains the split) is built once; the
+  // rest of the fabric streams around the camera in updateStreaming.
+  private parcelStreamer: ParcelStreamer | null = null;
+  parcelStreamStats(): ParcelStreamStats | null {
+    return this.parcelStreamer?.stats() ?? null;
+  }
   private async buildParcels(): Promise<void> {
     const t0 = performance.now();
     const { plans, lots } = this.parcelPlan();
+    const detail = parcelDetailLevel();
+    const skyline = plans.filter((p) => p.height >= BIG_SILHOUETTE_H);
+    const fabric = plans.filter((p) => p.height < BIG_SILHOUETTE_H);
     const built = await buildParcelFabric(
-      plans,
-      lots,
+      skyline,
+      [],
       { imposter: IMPOSTER_DISTANCE, midImposter: MID_IMPOSTER_DISTANCE, detail: DETAIL_DISTANCE },
-      parcelDetailLevel(),
+      detail,
       () => this.breathe(),
     );
     for (const c of built.chunks) {
       this.group.add(c.group);
       this.chunks.push({ cx: c.cx, cz: c.cz, radius: c.radius, dist: c.dist, group: c.group });
     }
+    this.parcelStreamer = new ParcelStreamer(this.group, fabric, lots, detail);
     for (const p of plans) for (const so of p.solids) this.solids.push(so);
-    this.parkedCarSpecs = [...this.parkedCarSpecs, ...built.parkedCars];
+    const cars = parkOnLots(lots, plans);
+    this.parkedCarSpecs = [...this.parkedCarSpecs, ...cars];
     console.log(
-      `[city] parcels built: ${plans.length} buildings, ${lots.length} lots (${built.parkedCars.length} cars), ${built.stats.vertices} verts, ` +
-        `${built.stats.buffers} buffers in ${Math.round(performance.now() - t0)}ms`,
+      `[city] parcels: ${skyline.length} skyline buildings static (${built.stats.vertices} verts), ` +
+        `${fabric.length} streamed over ${this.parcelStreamer.stats().cells} cells, ${lots.length} lots ` +
+        `(${cars.length} cars) in ${Math.round(performance.now() - t0)}ms`,
     );
   }
   private lateRoadFallback: (() => void) | null = null;
@@ -2366,6 +2379,11 @@ export class CityModel {
   updateStreaming(camera: THREE.Camera, showAll = false): void {
     const camX = camera.position.x;
     const camZ = camera.position.z;
+    this.parcelStreamer?.update(
+      camX,
+      camZ,
+      showAll ? Infinity : streamRadiusFor(liveQuality().detailScale),
+    );
     for (const c of this.chunks) {
       const d = Math.hypot(camX - c.cx, camZ - c.cz) - c.radius;
       const visible = showAll || d < c.dist;

--- a/games/crazy-waymo/src/world/parcel-build.ts
+++ b/games/crazy-waymo/src/world/parcel-build.ts
@@ -195,7 +195,7 @@ export function setParcelNight(night: number): void {
   FACADE_NIGHT.value = Math.max(0, Math.min(1, night));
 }
 
-function materialFor(mat: ParcelMaterial): THREE.MeshStandardMaterial {
+export function materialFor(mat: ParcelMaterial): THREE.MeshStandardMaterial {
   switch (mat) {
     case "wall":
       return WALL;
@@ -235,7 +235,7 @@ export function parcelDetailLevel(): DetailLevel {
   return isCoarsePointer() ? 1 : 2;
 }
 
-function geometryOf(g: ParcelGeo): THREE.BufferGeometry {
+export function parcelGeometryOf(g: ParcelGeo): THREE.BufferGeometry {
   const geo = new THREE.BufferGeometry();
   geo.setAttribute("position", new THREE.BufferAttribute(g.position, 3));
   geo.setAttribute("normal", new THREE.BufferAttribute(g.normal, 3, true));
@@ -273,7 +273,7 @@ export async function buildParcelFabric(
       chunk.group.name = `parcels-${g.tier}`;
       groups.set(key, chunk);
     }
-    const mesh = new THREE.Mesh(geometryOf(g), materialFor(g.mat));
+    const mesh = new THREE.Mesh(parcelGeometryOf(g), materialFor(g.mat));
     mesh.name = `parcel-${g.tier}-${g.mat}`;
     // Bodies throw the street shadows; the decals and ledges only catch them.
     mesh.castShadow = g.tier !== "detail";
@@ -333,7 +333,7 @@ class BuildingIndex {
   }
 }
 
-function parkOnLots(lots: readonly ParcelLot[], plans: readonly ParcelPlan[]): ParkedSpec[] {
+export function parkOnLots(lots: readonly ParcelLot[], plans: readonly ParcelPlan[]): ParkedSpec[] {
   const out: ParkedSpec[] = [];
   const buildings = new BuildingIndex(plans);
   for (const lot of lots) {

--- a/games/crazy-waymo/src/world/parcel-mesh.ts
+++ b/games/crazy-waymo/src/world/parcel-mesh.ts
@@ -1514,6 +1514,18 @@ export async function buildParcelGeometry(
   return buckets.flush();
 }
 
+/** The same, synchronously — one stream cell's worth, inside a frame budget. */
+export function buildParcelGeometrySync(
+  plans: readonly ParcelPlan[],
+  detail: DetailLevel,
+  lots: readonly ParcelLot[] = [],
+): ParcelGeometry {
+  const buckets = new Buckets();
+  for (const p of plans) buildOne(buckets, p, detail);
+  for (const lot of lots) buildLot(buckets, lot);
+  return buckets.flush();
+}
+
 // --- Surface lots ------------------------------------------------------------
 // A surveyed parcel with no building on it: asphalt draped on the ground with
 // bay lines, so a block face reads as parking rather than as a gap. Cars are

--- a/games/crazy-waymo/src/world/parcel-stream.ts
+++ b/games/crazy-waymo/src/world/parcel-stream.ts
@@ -1,0 +1,191 @@
+import * as THREE from "three";
+
+import { DRAW_DISTANCE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { materialFor, parcelGeometryOf } from "./parcel-build";
+import { buildParcelGeometrySync, type DetailLevel, type ParcelGeoStats } from "./parcel-mesh";
+import type { ParcelLot, ParcelPlan } from "./parcel-plan";
+
+// The parcel fabric, STREAMED. Nothing past the fog line is visible, so the
+// city's 130k buildings do not need to be on the GPU at once: the plan is
+// grouped into 80u cells, a cell's geometry is generated when it comes
+// within the stream radius and freed once it falls well outside it. A cell
+// is ~100 parcels and builds in about 2 ms, so the frontier keeps up with
+// the car at one cell a frame, nearest first (a 160u cell at two a frame was
+// a 37 ms hitch); the first tick after a load, and any teleport, fills the
+// whole radius at once.
+//
+// The skyline is the exception. Towers read from 1400u away and there are
+// only a few hundred, so they are built once, statically, by the city
+// (parcel-build.ts) and never enter the streamer.
+
+export const STREAM_CELL = 80;
+/** How far past the fog line cells are held: nothing pops inside it. */
+const STREAM_PAD = 60;
+/** A cell is freed this far beyond the build radius, so a U-turn does not thrash. */
+const STREAM_HYSTERESIS = 180;
+/** Cells built per tick after the first fill. */
+const BUILDS_PER_TICK = 1;
+
+/** Radius the fabric is held to, for a quality tier's model band. */
+export function streamRadiusFor(detailScale: number): number {
+  return (DRAW_DISTANCE + STREAM_PAD) * (detailScale < 1 ? 0.72 : 1);
+}
+
+export const streamCellKey = (x: number, z: number): number =>
+  Math.floor((x + WORLD_HALF_X) / STREAM_CELL) * 4096 +
+  Math.floor((z + WORLD_HALF_Z) / STREAM_CELL);
+
+export type StreamCellPlans = { readonly plans: ParcelPlan[]; readonly lots: ParcelLot[] };
+
+/** Split plans and lots into stream cells by their centre. */
+export function streamCells(
+  plans: readonly ParcelPlan[],
+  lots: readonly ParcelLot[],
+): ReadonlyMap<number, StreamCellPlans> {
+  const cells = new Map<number, StreamCellPlans>();
+  const at = (x: number, z: number): StreamCellPlans => {
+    const k = streamCellKey(x, z);
+    let c = cells.get(k);
+    if (!c) {
+      c = { plans: [], lots: [] };
+      cells.set(k, c);
+    }
+    return c;
+  };
+  for (const p of plans) at(p.obb.cx, p.obb.cz).plans.push(p);
+  for (const l of lots) at(l.obb.cx, l.obb.cz).lots.push(l);
+  return cells;
+}
+
+/** GPU bytes of built geometry, as three uploads it. */
+export function geometryBytes(stats: ParcelGeoStats, facadeVerts: number): number {
+  return stats.vertices * (12 + 3 + 3) + facadeVerts * (4 + 8 + 4) + stats.triangles * 3 * 2;
+}
+
+type Cell = {
+  readonly key: number;
+  readonly cx: number;
+  readonly cz: number;
+  readonly plans: ParcelPlan[];
+  readonly lots: ParcelLot[];
+  group: THREE.Group | null;
+  verts: number;
+  bytes: number;
+};
+
+export type ParcelStreamStats = {
+  readonly cells: number;
+  readonly resident: number;
+  readonly verts: number;
+  readonly bytes: number;
+  readonly builtMs: number;
+};
+
+export class ParcelStreamer {
+  private readonly cells = new Map<number, Cell>();
+  private readonly resident = new Set<number>();
+  private filled = false;
+  private builtMs = 0;
+
+  constructor(
+    private readonly root: THREE.Object3D,
+    plans: readonly ParcelPlan[],
+    lots: readonly ParcelLot[],
+    private readonly detail: DetailLevel,
+  ) {
+    for (const [key, c] of streamCells(plans, lots)) {
+      const gx = Math.floor(key / 4096);
+      const gz = key % 4096;
+      this.cells.set(key, {
+        key,
+        cx: (gx + 0.5) * STREAM_CELL - WORLD_HALF_X,
+        cz: (gz + 0.5) * STREAM_CELL - WORLD_HALF_Z,
+        plans: c.plans,
+        lots: c.lots,
+        group: null,
+        verts: 0,
+        bytes: 0,
+      });
+    }
+  }
+
+  stats(): ParcelStreamStats {
+    let verts = 0;
+    let bytes = 0;
+    for (const k of this.resident) {
+      const c = this.cells.get(k);
+      if (!c) continue;
+      verts += c.verts;
+      bytes += c.bytes;
+    }
+    return {
+      cells: this.cells.size,
+      resident: this.resident.size,
+      verts,
+      bytes,
+      builtMs: this.builtMs,
+    };
+  }
+
+  /**
+   * Hold the fabric around (x, z) to `radius`. The first call fills the
+   * whole radius synchronously — it runs under the loading screen or a
+   * teleport — and every call after builds at most a few cells, nearest
+   * first, and frees cells that have fallen out of the hysteresis band.
+   */
+  update(x: number, z: number, radius: number): void {
+    const want: Cell[] = [];
+    const drop = radius + STREAM_HYSTERESIS;
+    for (const c of this.cells.values()) {
+      const d = Math.hypot(c.cx - x, c.cz - z);
+      if (c.group === null) {
+        if (d < radius) want.push(c);
+      } else if (d > drop) {
+        this.free(c);
+      }
+    }
+    if (want.length === 0) return;
+    want.sort((a, b) => Math.hypot(a.cx - x, a.cz - z) - Math.hypot(b.cx - x, b.cz - z));
+    const budget = this.filled ? BUILDS_PER_TICK : want.length;
+    for (let i = 0; i < Math.min(budget, want.length); i++) {
+      const c = want[i];
+      if (c) this.build(c);
+    }
+    this.filled = true;
+  }
+
+  private build(c: Cell): void {
+    const t0 = performance.now();
+    const geometry = buildParcelGeometrySync(c.plans, this.detail, c.lots);
+    const group = new THREE.Group();
+    group.name = "parcel-cell";
+    let facadeVerts = 0;
+    for (const g of geometry.geos) {
+      const mesh = new THREE.Mesh(parcelGeometryOf(g), materialFor(g.mat));
+      mesh.name = `parcel-${g.tier}-${g.mat}`;
+      mesh.castShadow = g.tier !== "detail";
+      mesh.receiveShadow = true;
+      mesh.matrixAutoUpdate = false;
+      group.add(mesh);
+      if (g.fuv) facadeVerts += g.position.length / 3;
+    }
+    c.group = group;
+    c.verts = geometry.stats.vertices;
+    c.bytes = geometryBytes(geometry.stats, facadeVerts);
+    this.root.add(group);
+    this.resident.add(c.key);
+    this.builtMs += performance.now() - t0;
+  }
+
+  private free(c: Cell): void {
+    if (c.group === null) return;
+    for (const child of c.group.children) {
+      if (child instanceof THREE.Mesh) child.geometry.dispose();
+    }
+    this.root.remove(c.group);
+    c.group = null;
+    c.verts = 0;
+    c.bytes = 0;
+    this.resident.delete(c.key);
+  }
+}

--- a/games/crazy-waymo/tools/test-world.mts
+++ b/games/crazy-waymo/tools/test-world.mts
@@ -15,6 +15,7 @@ import {
 import { freewayPillars } from "../src/world/freeways.ts";
 import { landmarkProtection } from "../src/world/landmarks.ts";
 import { buildParcelGeometry } from "../src/world/parcel-mesh.ts";
+import { geometryBytes, streamCellKey, streamRadiusFor } from "../src/world/parcel-stream.ts";
 import { planParcels } from "../src/world/parcel-plan.ts";
 import { RoadNetwork } from "../src/world/network.ts";
 import { buildJunctionMap } from "../src/world/roads.ts";
@@ -718,36 +719,47 @@ console.log(`  (plan + network in ${Math.round(performance.now() - t0)}ms)`);
     k("rowhouse") + k("stucco") >= 90000 && k("midrise") >= 8000 && k("tower") >= 300,
     [...kinds.entries()].map(([n, c]) => `${n} ${c}`).join(", "),
   );
-  // Vertex budget: the whole fabric lives on the GPU at once (chunks hide,
-  // they do not unload), so this is memory as much as it is draw time. The
-  // survey parcels carry ~250 vertices each and the lean citywide fabric ~40;
-  // the phone number waits on #304 (shader windows on the survey flanks and
-  // quantized attributes) to come down.
-  // GPU bytes as three uploads them: f32 position, i8 normal, u8 colour, the
-  // facade walls' u16 fuv + u16 facade + u8 facade2, and the index.
-  const gpuBytes = (g: Awaited<ReturnType<typeof buildParcelGeometry>>): number => {
-    let b = 0;
-    for (const geo of g.geos) {
-      const v = geo.position.length / 3;
-      b += v * (12 + 3 + 3) + geo.index.byteLength;
-      if (geo.fuv) b += v * (4 + 8 + 4);
-    }
-    return b;
+  // GPU budget. The skyline is resident everywhere; the rest of the fabric
+  // streams in 160u cells around the camera (parcel-stream.ts), so what
+  // matters is the WORST neighbourhood: the cells within the stream radius of
+  // the densest spot, FiDi, plus the skyline. Phones hold a shorter radius.
+  const bytesOf = (g: Awaited<ReturnType<typeof buildParcelGeometry>>): number => {
+    let facade = 0;
+    for (const geo of g.geos) if (geo.fuv) facade += geo.position.length / 3;
+    return geometryBytes(g.stats, facade);
   };
+  const skyline = parcels.plans.filter((p) => p.height >= 13);
+  const fabric = parcels.plans.filter((p) => p.height < 13);
   const t1 = performance.now();
-  const full = await buildParcelGeometry(parcels.plans, 2);
-  const fullMs = Math.round(performance.now() - t1);
+  const sky = await buildParcelGeometry(skyline, 2);
+  const skyMs = Math.round(performance.now() - t1);
   check(
-    "parcel geometry fits the desktop budget",
-    full.stats.vertices <= 9_500_000,
-    `${full.stats.vertices} verts, ${Math.round(full.stats.triangles)} tris, ${full.stats.buffers} buffers, ` +
-      `${(gpuBytes(full) / 1048576).toFixed(0)} MB on the GPU, in ${fullMs}ms`,
+    "the static skyline stays small",
+    skyline.length <= 1200 && bytesOf(sky) <= 20 * 1048576,
+    `${skyline.length} towers, ${sky.stats.vertices} verts, ${(bytesOf(sky) / 1048576).toFixed(1)} MB in ${skyMs}ms`,
   );
-  const phone = await buildParcelGeometry(parcels.plans, 1);
+  const resident = async (x: number, z: number, radius: number, detail: 1 | 2) => {
+    const keys = new Set<number>();
+    for (const p of fabric) {
+      if (Math.hypot(p.obb.cx - x, p.obb.cz - z) < radius + 120)
+        keys.add(streamCellKey(p.obb.cx, p.obb.cz));
+    }
+    const within = fabric.filter((p) => keys.has(streamCellKey(p.obb.cx, p.obb.cz)));
+    const lotsWithin = parcels.lots.filter((l) => keys.has(streamCellKey(l.obb.cx, l.obb.cz)));
+    const g = await buildParcelGeometry(within, detail, undefined, lotsWithin);
+    return { parcels: within.length, verts: g.stats.vertices, mb: bytesOf(g) / 1048576 };
+  };
+  const fidi = await resident(640, -830, streamRadiusFor(1), 2);
   check(
-    "parcel geometry fits the phone budget",
-    phone.stats.vertices <= 7_600_000,
-    `${phone.stats.vertices} verts, ${phone.stats.buffers} buffers, ${(gpuBytes(phone) / 1048576).toFixed(0)} MB on the GPU`,
+    "resident fabric at FiDi fits the desktop budget",
+    fidi.mb + bytesOf(sky) / 1048576 <= 110,
+    `${fidi.parcels} parcels, ${fidi.verts} verts, ${fidi.mb.toFixed(0)} MB + skyline`,
+  );
+  const fidiPhone = await resident(640, -830, streamRadiusFor(0.6), 1);
+  check(
+    "resident fabric at FiDi fits the phone budget",
+    fidiPhone.mb + bytesOf(sky) / 1048576 <= 70,
+    `${fidiPhone.parcels} parcels, ${fidiPhone.verts} verts, ${fidiPhone.mb.toFixed(0)} MB + skyline`,
   );
 }
 


### PR DESCRIPTION
## What

The parcel fabric streams instead of staying resident.

- `parcel-stream.ts` — plans and lots grouped into 80u cells; a cell is generated when it comes within the fog line + 60u of the camera (one per frame, nearest first) and freed 180u past it. The first tick after a load or teleport fills the whole radius at once.
- The skyline (~260 parcels ≥ 13u) is still built once, statically — towers read from 1400u and there are few.
- `city.parcelStreamStats()` reports residency; the harness budgets the densest probe (FiDi) at the desktop and phone radii and asserts the skyline stays small.

| | before | after |
|---|---|---|
| GPU resident, desktop | 241 MB (whole city) | 97 MB at FiDi |
| GPU resident, phone radius | 213 MB | 48 MB at FiDi |
| Static skyline | — | 260 towers, 1.1 MB |
| Driving fps (desktop, cold gen) | 110 | 109; worst frame 12 ms once driving |

Runtime only: no rebake, `WORLD_REV` unchanged. `pnpm test` 40/40.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams the parcel fabric around the camera so the GPU holds only the geometry near the player instead of the whole city. Residency at the densest probe (FiDi) drops from 241 MB to 97 MB on desktop and from 213 MB to 48 MB on the phone tier, with driving fps effectively unchanged; the change is runtime-only, so no rebake is needed and `WORLD_REV` stays the same.

**Streaming**
- The skyline (~260 parcels ≥ 13u) is still built once and statically; everything else is grouped into 80u cells.
- Cells are built one per frame, nearest-first, when they come within the fog line + 60u of the camera, and freed 180u past it; the first tick after a load or teleport fills the radius at once.
- `city.parcelStreamStats()` reports residency, and the harness now budgets the densest probe instead of the whole city; `pnpm test` stays 40/40.

Closes #313

<sup>Written for commit c66f424bdb3da23e7cda4d8512ac712b9dbaab4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

