### PR TITLE
crazy-waymo: start the parcel worker on source arrival, cache its plan

### DIFF
--- a/games/crazy-waymo/src/scenes/world-loader.ts
+++ b/games/crazy-waymo/src/scenes/world-loader.ts
@@ -25,8 +25,10 @@ import type { CityGenPayload } from "../world/gen-worker";
 import { getRuntimeMap, parseMapFile, setRuntimeMap } from "../world/map-file";
 import { SolidIndex } from "../world/solid-index";
 import {
+  readParcelPlanCache,
   readRestCache,
   readWorldCache,
+  writeParcelPlanCache,
   writeRestCache,
   writeWorldCache,
 } from "../world/world-cache";
@@ -110,6 +112,10 @@ function cityEdited(): boolean {
   );
 }
 
+function fromWorker(r: ParcelWorkerResponse): ParcelPlanResult {
+  return { plans: r.plans, lots: r.lots, stats: r.stats, covered: new Set(r.covered) };
+}
+
 /** The worker's plan, or the decoded source for the city to plan from itself. */
 type ParcelResolved = {
   readonly plan: ParcelPlanResult | null;
@@ -129,10 +135,8 @@ function startGenWorker(): Promise<CityGenPayload | null> {
  * The parcel plan in its worker (world/parcel-worker.ts). Resolves null on
  * any failure and the city plans on the main thread instead.
  */
-function runParcelWorker(
-  source: ArrayBuffer,
-  reserved: readonly string[],
-): Promise<ParcelPlanResult | null> {
+function runParcelWorker(source: ArrayBuffer): Promise<ParcelPlanResult | null> {
+  const bytes = source.byteLength;
   return new Promise((resolve) => {
     try {
       const worker = new Worker(new URL("../world/parcel-worker.ts", import.meta.url), {
@@ -141,7 +145,8 @@ function runParcelWorker(
       worker.onmessage = (ev: MessageEvent<ParcelWorkerResponse>) => {
         const r = ev.data;
         console.log(`[parcel-worker] planned ${r.plans.length} parcels in ${r.ms}ms`);
-        resolve({ plans: r.plans, lots: r.lots, stats: r.stats, covered: new Set(r.covered) });
+        writeParcelPlanCache(bytes, r);
+        resolve(fromWorker(r));
         worker.terminate();
       };
       worker.onerror = (e) => {
@@ -149,7 +154,7 @@ function runParcelWorker(
         resolve(null);
         worker.terminate();
       };
-      const req: ParcelWorkerRequest = { source, reserved };
+      const req: ParcelWorkerRequest = { source };
       worker.postMessage(req, [source]);
     } catch (e) {
       console.log(`[parcel-worker] unavailable: ${e instanceof Error ? e.message : e}`);
@@ -217,9 +222,26 @@ export async function loadWorld(deps: WorldLoaderDeps): Promise<WorldLoadResult>
   const bakedWorldPromise = skipBaked ? Promise.resolve(null) : fetchBakedWorld();
   const bakedRestPromise = skipBaked ? Promise.resolve(null) : fetchBakedRest();
   // The parcel source is an INPUT to the city, not a baked output: every
-  // path fetches it, bake mode included. Raw bytes, because the plan runs in
-  // a worker and the buffer is transferred there.
-  const parcelBytesPromise = fetchParcelSource();
+  // path fetches it, bake mode included. The plan starts in its worker the
+  // moment the bytes land — it assembles its own reservation — so it runs
+  // under the model download and the title screen rather than after them.
+  // An edited city has a grid-derived network the worker does not have and
+  // plans itself, later, from the decoded source.
+  const parcelPromise: Promise<ParcelResolved> = fetchParcelSource().then(async (bytes) => {
+    if (!bytes) return { plan: null, source: null };
+    if (edited) return { plan: null, source: decodeParcelSource(bytes) };
+    // A revisit has the plan already (world-cache.ts): the same build, rev
+    // and source bytes, so the worker would compute the identical result.
+    const cached = await readParcelPlanCache(bytes.byteLength);
+    if (cached) {
+      console.log(`[parcel-worker] plan from cache: ${cached.plans.length} parcels`);
+      return { plan: fromWorker(cached), source: null };
+    }
+    // Decode a copy for the fallback before the buffer is transferred away.
+    const copy = bytes.slice(0);
+    const plan = await runParcelWorker(bytes);
+    return { plan, source: plan ? null : decodeParcelSource(copy) };
+  });
   const genPromise = bakedWorldPromise.then((baked) => baked ?? startGenWorker());
   const restState: RestState = { fromBake: false };
   const restPromise = bakedRestPromise.then((baked) => {
@@ -273,17 +295,6 @@ export async function loadWorld(deps: WorldLoaderDeps): Promise<WorldLoadResult>
   deps.snapToCar(car);
   deps.hideLoading();
   deps.showTitle();
-  // The plan needs phase 1's reservation (initEarly above) and the baked
-  // network; an edited city has neither and plans itself.
-  const parcelPromise: Promise<ParcelResolved> = parcelBytesPromise.then(async (bytes) => {
-    if (!bytes) return { plan: null, source: null };
-    if (edited) return { plan: null, source: decodeParcelSource(bytes) };
-    const reserved = city.parcelReservation();
-    // Decode a copy for the fallback before the buffer is transferred away.
-    const copy = bytes.slice(0);
-    const plan = await runParcelWorker(bytes, reserved);
-    return { plan, source: plan ? null : decodeParcelSource(copy) };
-  });
   const ready = finishLoad(
     deps,
     city,

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -22,6 +22,9 @@ import { Rng } from "../shared/rng";
 import { DIR_DELTA, E, N, S, W } from "../shared/types";
 import { type DrapeField, toFloat32Attributes } from "./conform";
 import { activeMapProps } from "./map-file";
+import { type Garage, pickGarageSpots } from "./garages";
+export type { Garage } from "./garages";
+import { buildReservation } from "./reservation";
 import { buildFurniture, type LampHead, type ParkedSpec } from "./furniture";
 import type { GoldenGatePlan } from "./golden-gate";
 import { buildGoldenGate, goldenGateBeacons, goldenGatePlan } from "./golden-gate";
@@ -89,11 +92,6 @@ export function facadeOffset(half: number): number {
  * with no fence, path or yard.
  */
 export const STEEP_CLIFF = 6.5;
-
-// Grid cell of a world position. The City methods delegate here so the fabric
-// planner (module scope, no instance) and the class cannot drift.
-const gridXOf = (x: number): number => Math.floor((x + WORLD_HALF_X) / ROAD_TILE);
-const gridZOf = (z: number): number => Math.floor((z + WORLD_HALF_Z) / ROAD_TILE);
 
 // --- Occupancy: rotated RECTANGLES, and a row can never reject itself.
 // Buildings are boxes, and the circle this used to keep made a 6u-wide lot claim
@@ -737,93 +735,6 @@ function imposterBox(geo: THREE.BufferGeometry, mat: THREE.Material): THREE.Buff
   return box;
 }
 
-// A robotaxi garage: the depot building plus the drive-in pad in front where
-// the skin-swap UI opens. Spots are derived deterministically from the plan,
-// so BOTH the generated and the baked-artifact boot paths agree on them.
-export type Garage = { x: number; z: number; yaw: number; padX: number; padZ: number };
-
-const GARAGE_COUNT = 7;
-const GARAGE_MIN_DIST = 350;
-
-function pickGarageSpots(plan: CityPlan, terrain: Terrain, network: RoadNetwork): Garage[] {
-  const cells = plan.cells;
-  const dirs: readonly (readonly [number, number])[] = [
-    [1, 0],
-    [-1, 0],
-    [0, 1],
-    [0, -1],
-  ];
-  const cellAt = (gx: number, gz: number): string | undefined => cells[gx]?.[gz];
-  type Cand = { gx: number; gz: number; dx: number; dz: number };
-  const cands: Cand[] = [];
-  for (let gx = 4; gx < GRID_X - 4; gx += 2) {
-    for (let gz = 4; gz < GRID_Z - 4; gz += 2) {
-      if (cellAt(gx, gz) !== "lot") continue;
-      for (const [dx, dz] of dirs) {
-        if (cellAt(gx + dx, gz + dz) !== "road") continue;
-        // depth: the cell behind must be lot too (the depot is deep)
-        if (cellAt(gx - dx, gz - dz) !== "lot") continue;
-        const wx = (gx + 0.5) * ROAD_TILE - WORLD_HALF_X;
-        const wz = (gz + 0.5) * ROAD_TILE - WORLD_HALF_Z;
-        const r = ROAD_TILE;
-        const hs = [
-          terrain.heightAt(wx - r, wz - r),
-          terrain.heightAt(wx + r, wz - r),
-          terrain.heightAt(wx - r, wz + r),
-          terrain.heightAt(wx + r, wz + r),
-        ];
-        if (Math.max(...hs) - Math.min(...hs) > 1.4) continue; // flat pads only
-        cands.push({ gx, gz, dx, dz });
-        break;
-      }
-    }
-  }
-  // Seeded shuffle, then greedy max-spread accept.
-  const rng = new Rng(424242);
-  for (let i = cands.length - 1; i > 0; i--) {
-    const j = rng.int(i + 1);
-    const a = cands[i];
-    const b = cands[j];
-    if (a && b) {
-      cands[i] = b;
-      cands[j] = a;
-    }
-  }
-  const picked: Garage[] = [];
-  for (const c of cands) {
-    if (picked.length >= GARAGE_COUNT) break;
-    const wx = (c.gx + 0.5) * ROAD_TILE - WORLD_HALF_X;
-    const wz = (c.gz + 0.5) * ROAD_TILE - WORLD_HALF_Z;
-    if (picked.some((g) => Math.hypot(g.x - wx, g.z - wz) < GARAGE_MIN_DIST)) continue;
-    // Depot footprint must not clip a vector lane: the grid says "lot" but
-    // straightened OSM centrelines cut lot cells, and a depot corner in the
-    // roadway is an (invisible from the lane) wall.
-    const dh = ROAD_TILE * 0.42 + 0.3;
-    let clipsLane = false;
-    for (const [ox, oz] of [
-      [-dh, -dh],
-      [dh, -dh],
-      [-dh, dh],
-      [dh, dh],
-    ] as const) {
-      const hit = network.nearest(wx + ox, wz + oz, ROAD_TILE * 1.4);
-      if (hit && hit.dist < hit.edge.half + 0.2) {
-        clipsLane = true;
-        break;
-      }
-    }
-    if (clipsLane) continue;
-    picked.push({
-      x: wx,
-      z: wz,
-      yaw: Math.atan2(c.dx, c.dz), // model faces +Z — turn it toward the road
-      padX: wx + c.dx * ROAD_TILE * 1.15,
-      padZ: wz + c.dz * ROAD_TILE * 1.15,
-    });
-  }
-  return picked;
-}
-
 export class CityModel {
   readonly group = new THREE.Group();
   readonly solids: Solid[] = [];
@@ -1044,10 +955,6 @@ export class CityModel {
   /** The parcel source (world-fetch.ts fetchParcelSource) — the main-thread fallback's input. */
   setParcelSource(src: ParcelSource | null): void {
     this.parcelSource = src;
-  }
-  /** Cells no parcel may touch, as phase 1 assembled them — what the parcel worker plans against. */
-  parcelReservation(): string[] {
-    return [...this.reservedCells];
   }
   private parcelPlanCache: ParcelPlanResult | null = null;
   /** The plan, computed off-thread (parcel-worker.ts) — set before initLate(). */
@@ -1421,40 +1328,17 @@ export class CityModel {
     // --- Landmark footprints: cells the procedural city leaves alone.
     // Editor "clear" cells join the reservation, so every placement pass
     // (buildings, furniture, park tiles) skips them. ---
+    // Assembled by the ONE builder the parcel worker also uses
+    // (world/reservation.ts), so the plan it computes before this phase runs
+    // is against exactly this set.
     const lmBase = landmarkProtection(this.plan, this.network);
-    const reservedAll = new Set(lmBase.reserved);
-    for (const [cgx, cgz] of loadLocalOverrides().clear ?? []) {
-      reservedAll.add(`${cgx},${cgz}`);
-    }
-    // The Golden Gate corridor. buildGoldenGate runs LAST (phase 3), so its
-    // deck does not exist yet when the vegetation and furniture passes seat
-    // props — and the deck is not network asphalt, so `onAsphalt` cannot see it
-    // either. The result was a kit conifer planted on the deck centreline at
-    // the bridge axis, straddling both lanes. Reserving the corridor up front
-    // is the only place that knowledge can live for every later pass.
-    {
-      const gg = goldenGatePlan({
-        plan: this.plan,
-        terrain: this.terrain,
-        worldX: (g) => this.worldX(g),
-        worldZ: (g) => this.worldZ(g),
-      });
-      if (gg) {
-        const gx0 = gridXOf(gg.ax - gg.half - ROAD_TILE * 0.5);
-        const gx1 = gridXOf(gg.ax + gg.half + ROAD_TILE * 0.5);
-        const gz0 = gridZOf(Math.min(gg.northEndZ, gg.shoreZ));
-        const gz1 = gridZOf(Math.max(gg.northEndZ, gg.shoreZ));
-        for (let gx = gx0; gx <= gx1; gx++) {
-          for (let gz = gz0; gz <= gz1; gz++) reservedAll.add(`${gx},${gz}`);
-        }
-      }
-    }
-    // Garages claim their own cell AND their drive-in pad before anything else
-    // builds (or dresses) there.
-    for (const g of this.garages) {
-      reservedAll.add(`${gridXOf(g.x)},${gridZOf(g.z)}`);
-      reservedAll.add(`${gridXOf(g.padX)},${gridZOf(g.padZ)}`);
-    }
+    const reservedAll = buildReservation({
+      plan: this.plan,
+      terrain: this.terrain,
+      landmarks: lmBase.reserved,
+      garages: this.garages,
+      clears: loadLocalOverrides().clear ?? [],
+    });
     const lm = { ...lmBase, reserved: reservedAll };
     this.reservedCells = reservedAll;
     // Landmark monuments have visuals but are NOT batch items (built as

--- a/games/crazy-waymo/src/world/garages.ts
+++ b/games/crazy-waymo/src/world/garages.ts
@@ -1,0 +1,96 @@
+import { GRID_X, GRID_Z, ROAD_TILE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { Rng } from "../shared/rng";
+import type { CityPlan } from "./grid";
+import type { RoadNetwork } from "./network";
+import type { Terrain } from "./terrain";
+
+// The robotaxi depots: where the skin-swap garages stand. Pure in plan,
+// terrain and network, so the city's phase 1 and the parcel worker pick the
+// same seven spots and reserve the same cells around them.
+
+// A robotaxi garage: the depot building plus the drive-in pad in front where
+// the skin-swap UI opens. Spots are derived deterministically from the plan,
+// so BOTH the generated and the baked-artifact boot paths agree on them.
+export type Garage = { x: number; z: number; yaw: number; padX: number; padZ: number };
+
+const GARAGE_COUNT = 7;
+const GARAGE_MIN_DIST = 350;
+
+export function pickGarageSpots(plan: CityPlan, terrain: Terrain, network: RoadNetwork): Garage[] {
+  const cells = plan.cells;
+  const dirs: readonly (readonly [number, number])[] = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ];
+  const cellAt = (gx: number, gz: number): string | undefined => cells[gx]?.[gz];
+  type Cand = { gx: number; gz: number; dx: number; dz: number };
+  const cands: Cand[] = [];
+  for (let gx = 4; gx < GRID_X - 4; gx += 2) {
+    for (let gz = 4; gz < GRID_Z - 4; gz += 2) {
+      if (cellAt(gx, gz) !== "lot") continue;
+      for (const [dx, dz] of dirs) {
+        if (cellAt(gx + dx, gz + dz) !== "road") continue;
+        // depth: the cell behind must be lot too (the depot is deep)
+        if (cellAt(gx - dx, gz - dz) !== "lot") continue;
+        const wx = (gx + 0.5) * ROAD_TILE - WORLD_HALF_X;
+        const wz = (gz + 0.5) * ROAD_TILE - WORLD_HALF_Z;
+        const r = ROAD_TILE;
+        const hs = [
+          terrain.heightAt(wx - r, wz - r),
+          terrain.heightAt(wx + r, wz - r),
+          terrain.heightAt(wx - r, wz + r),
+          terrain.heightAt(wx + r, wz + r),
+        ];
+        if (Math.max(...hs) - Math.min(...hs) > 1.4) continue; // flat pads only
+        cands.push({ gx, gz, dx, dz });
+        break;
+      }
+    }
+  }
+  // Seeded shuffle, then greedy max-spread accept.
+  const rng = new Rng(424242);
+  for (let i = cands.length - 1; i > 0; i--) {
+    const j = rng.int(i + 1);
+    const a = cands[i];
+    const b = cands[j];
+    if (a && b) {
+      cands[i] = b;
+      cands[j] = a;
+    }
+  }
+  const picked: Garage[] = [];
+  for (const c of cands) {
+    if (picked.length >= GARAGE_COUNT) break;
+    const wx = (c.gx + 0.5) * ROAD_TILE - WORLD_HALF_X;
+    const wz = (c.gz + 0.5) * ROAD_TILE - WORLD_HALF_Z;
+    if (picked.some((g) => Math.hypot(g.x - wx, g.z - wz) < GARAGE_MIN_DIST)) continue;
+    // Depot footprint must not clip a vector lane: the grid says "lot" but
+    // straightened OSM centrelines cut lot cells, and a depot corner in the
+    // roadway is an (invisible from the lane) wall.
+    const dh = ROAD_TILE * 0.42 + 0.3;
+    let clipsLane = false;
+    for (const [ox, oz] of [
+      [-dh, -dh],
+      [dh, -dh],
+      [-dh, dh],
+      [dh, dh],
+    ] as const) {
+      const hit = network.nearest(wx + ox, wz + oz, ROAD_TILE * 1.4);
+      if (hit && hit.dist < hit.edge.half + 0.2) {
+        clipsLane = true;
+        break;
+      }
+    }
+    if (clipsLane) continue;
+    picked.push({
+      x: wx,
+      z: wz,
+      yaw: Math.atan2(c.dx, c.dz), // model faces +Z — turn it toward the road
+      padX: wx + c.dx * ROAD_TILE * 1.15,
+      padZ: wz + c.dz * ROAD_TILE * 1.15,
+    });
+  }
+  return picked;
+}

--- a/games/crazy-waymo/src/world/parcel-worker.ts
+++ b/games/crazy-waymo/src/world/parcel-worker.ts
@@ -1,19 +1,24 @@
+import { pickGarageSpots } from "./garages";
+import { generateCity } from "./grid";
 import { makeGroundOffset, makeStandingSurface, makeTerracedDrapeField } from "./ground";
+import { landmarkProtection } from "./landmarks";
 import { RoadNetwork } from "./network";
 import { type ParcelPlanResult, planParcels } from "./parcel-plan";
 import { decodeParcelSource } from "./parcel-source";
+import { buildReservation } from "./reservation";
 import { makeTerrain } from "./sf-map";
 
 // The parcel PLAN, off the main thread. 147k footprints take a few seconds to
 // clip, seat and classify — long enough to freeze the title screen — and the
 // plan is pure (parcel-plan.ts), so it runs here against the same baked
-// network and terrain the city builds, from the reservation the city's
-// phase 1 already assembled. Edited cities (a grid-derived network) never
-// reach this worker: the city plans them itself.
+// network and terrain the city builds, and the same reservation
+// (world/reservation.ts), which it assembles itself so it can start the
+// moment the source bytes arrive rather than after the city's phase 1.
+// Edited cities (a grid-derived network, editor clears) never reach this
+// worker: the city plans them itself.
 
 export type ParcelWorkerRequest = {
   readonly source: ArrayBuffer;
-  readonly reserved: readonly string[];
 };
 
 /** The plan with its Set flattened: structured clone carries arrays and typed arrays. */
@@ -28,18 +33,20 @@ export type ParcelWorkerResponse = {
 self.onmessage = (ev: MessageEvent<ParcelWorkerRequest>): void => {
   const t0 = performance.now();
   const source = decodeParcelSource(ev.data.source);
+  const plan = generateCity();
   const network = new RoadNetwork();
   const terrain = makeTerrain();
   const groundOffset = makeGroundOffset(network, terrain);
   const drape = makeTerracedDrapeField(network, terrain);
   const standAt = makeStandingSurface(network, terrain, groundOffset, drape);
-  const result = planParcels({
-    source,
-    network,
+  const reserved = buildReservation({
+    plan,
     terrain,
-    reserved: new Set(ev.data.reserved),
-    standAt,
+    landmarks: landmarkProtection(plan, network).reserved,
+    garages: pickGarageSpots(plan, terrain, network),
+    clears: [],
   });
+  const result = planParcels({ source, network, terrain, reserved, standAt });
   const response: ParcelWorkerResponse = {
     plans: result.plans,
     lots: result.lots,

--- a/games/crazy-waymo/src/world/reservation.ts
+++ b/games/crazy-waymo/src/world/reservation.ts
@@ -1,0 +1,59 @@
+import { ROAD_TILE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { goldenGatePlan } from "./golden-gate";
+import type { CityPlan } from "./grid";
+import type { Terrain } from "./terrain";
+
+// The RESERVATION: every "gx,gz" cell no procedural placement may touch —
+// landmark parcels, the Golden Gate corridor, the robotaxi depots and their
+// drive-in pads, and the editor's cleared cells. One function, because two
+// callers assemble it: the city's phase 1 (which every later pass reads) and
+// the parcel worker, which starts before phase 1 exists and must plan against
+// exactly the same set or its buildings land on a landmark's lawn.
+
+export type ReservationInput = {
+  readonly plan: CityPlan;
+  readonly terrain: Terrain;
+  /** landmarkProtection(plan, network).reserved — the landmark parcels. */
+  readonly landmarks: ReadonlySet<string>;
+  readonly garages: readonly {
+    readonly x: number;
+    readonly z: number;
+    readonly padX: number;
+    readonly padZ: number;
+  }[];
+  /** Editor "clear" cells; none on the worker path (edited cities plan on the main thread). */
+  readonly clears: readonly (readonly [number, number])[];
+};
+
+const gridXOf = (x: number): number => Math.floor((x + WORLD_HALF_X) / ROAD_TILE);
+const gridZOf = (z: number): number => Math.floor((z + WORLD_HALF_Z) / ROAD_TILE);
+const worldX = (gx: number): number => (gx + 0.5) * ROAD_TILE - WORLD_HALF_X;
+const worldZ = (gz: number): number => (gz + 0.5) * ROAD_TILE - WORLD_HALF_Z;
+
+export function buildReservation(input: ReservationInput): Set<string> {
+  const reserved = new Set(input.landmarks);
+  for (const [gx, gz] of input.clears) reserved.add(`${gx},${gz}`);
+  // The Golden Gate corridor. buildGoldenGate runs LAST (phase 3), so its
+  // deck does not exist yet when the vegetation and furniture passes seat
+  // props — and the deck is not network asphalt, so `onAsphalt` cannot see it
+  // either. The result was a kit conifer planted on the deck centreline at
+  // the bridge axis, straddling both lanes. Reserving the corridor up front
+  // is the only place that knowledge can live for every later pass.
+  const gg = goldenGatePlan({ plan: input.plan, terrain: input.terrain, worldX, worldZ });
+  if (gg) {
+    const gx0 = gridXOf(gg.ax - gg.half - ROAD_TILE * 0.5);
+    const gx1 = gridXOf(gg.ax + gg.half + ROAD_TILE * 0.5);
+    const gz0 = gridZOf(Math.min(gg.northEndZ, gg.shoreZ));
+    const gz1 = gridZOf(Math.max(gg.northEndZ, gg.shoreZ));
+    for (let gx = gx0; gx <= gx1; gx++) {
+      for (let gz = gz0; gz <= gz1; gz++) reserved.add(`${gx},${gz}`);
+    }
+  }
+  // Garages claim their own cell AND their drive-in pad before anything else
+  // builds (or dresses) there.
+  for (const g of input.garages) {
+    reserved.add(`${gridXOf(g.x)},${gridZOf(g.z)}`);
+    reserved.add(`${gridXOf(g.padX)},${gridZOf(g.padZ)}`);
+  }
+  return reserved;
+}

--- a/games/crazy-waymo/src/world/world-cache.ts
+++ b/games/crazy-waymo/src/world/world-cache.ts
@@ -1,5 +1,7 @@
 import type { CityRestPayload } from "./city";
 import type { CityGenPayload } from "./gen-worker";
+import type { ParcelWorkerResponse } from "./parcel-worker";
+import { WORLD_REV } from "./world-bin";
 
 // IndexedDB cache for the worker-generated world: first visit pays the ~5-8s
 // generation once, every later visit loads the finished buffers in a few
@@ -136,4 +138,57 @@ export function writeWorldCache(payload: CityGenPayload): void {
         }),
     )
     .catch(() => {});
+}
+
+// --- The parcel plan -----------------------------------------------------------
+// The worker's plan for the whole city (parcel-worker.ts), so a revisit skips
+// the ~5 s it takes. Keyed like the rest cache — every deploy replans — and by
+// the source bytes and world rev, since the plan is a function of both.
+const PARCEL_KEY = "parcels";
+
+function parcelVersion(sourceBytes: number): string {
+  return `${buildId()}|rev${WORLD_REV}|src${sourceBytes}`;
+}
+
+export async function readParcelPlanCache(
+  sourceBytes: number,
+): Promise<ParcelWorkerResponse | null> {
+  if (!enabled()) return null;
+  try {
+    const db = await openDb();
+    const value = await new Promise<unknown>((resolve, reject) => {
+      const tx = db.transaction(STORE, "readonly");
+      const req = tx.objectStore(STORE).get(PARCEL_KEY);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error ?? new Error("idb read failed"));
+    });
+    db.close();
+    if (
+      value instanceof Object &&
+      "version" in value &&
+      "payload" in value &&
+      value.version === parcelVersion(sourceBytes)
+    ) {
+      // SAFETY: the only writer of this key is writeParcelPlanCache below, and
+      // the version string it stamps has just been matched.
+      return value.payload as ParcelWorkerResponse;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeParcelPlanCache(sourceBytes: number, payload: ParcelWorkerResponse): void {
+  if (!enabled()) return;
+  void openDb()
+    .then((db) => {
+      const tx = db.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).put({ version: parcelVersion(sourceBytes), payload }, PARCEL_KEY);
+      tx.oncomplete = () => db.close();
+      tx.onerror = () => db.close();
+    })
+    .catch(() => {
+      // best effort
+    });
 }


### PR DESCRIPTION
## What

- **Worker starts on source arrival.** It assembles its own reservation through the new `world/reservation.ts` — the one builder the city's phase 1 also uses — with the depot picker lifted into `world/garages.ts`. It no longer waits on phase 1, so it runs under the model download and the title screen.
- **Plan cached in IndexedDB** (`world-cache.ts`), keyed by build id + `WORLD_REV` + source bytes; revisits skip the ~5 s plan. Dev opts in with `?cache=1`.

| Baked path, local desktop | before | after |
|---|---|---|
| First visit (cache miss) | 10.4 s | 10.0 s |
| Revisit (cache hit) | 10.4 s | 4.1 s |
| Phone emulation, 4× CPU throttle, miss | 25.3 s | 19.1 s |

`pnpm test` 40/40 (the reservation is identical by construction). Runtime only, no rebake.

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The parcel worker now starts as soon as the city source bytes arrive, planning during the model download and title screen instead of waiting for phase 1, and its plan is cached in IndexedDB.

- The worker assembles its own reservation via the new shared `world/reservation.ts` builder (garage picking moved to `world/garages.ts`), so it no longer depends on phase 1.
- Revisits skip the ~5s plan computation, reading from IndexedDB keyed by build id, `WORLD_REV`, and source bytes; devs opt in with `?cache=1`.
- Desktop first visit: 10.4s → 10.0s; revisit: 10.4s → 4.1s. Phone emulation (4× CPU throttle) miss: 25.3s → 19.1s.
- Runtime only, no rebake; `pnpm test` stays 40/40.

Closes #314.

<sup>Written for commit cac8d6b780c3ad378bbe263f1cd387075e389485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

