### PR TITLE
Cut Crazy Waymo phone memory and report lost WebGL contexts

### DIFF
--- a/games/crazy-waymo/src/main.ts
+++ b/games/crazy-waymo/src/main.ts
@@ -13,14 +13,26 @@ import { createPauseOverlay } from "./ui/pause-overlay";
 const container = document.getElementById("game");
 if (!container) throw new Error("missing #game container");
 
-function showFatal(message: string): void {
+let reloadOnVeilTap = false;
+document.getElementById("loading")?.addEventListener("click", () => {
+  if (reloadOnVeilTap) window.location.reload();
+});
+
+function showFatal(message: string, tapToReload = false): void {
   const loading = document.getElementById("loading");
   if (loading) {
     // Trailer boots keep the veil hidden from the first paint (see index.html)
     // — a dead context still has to be reported, so force it back on screen.
     loading.style.display = "flex";
     loading.innerHTML = `<div class="lt">CRAZY WAYMO</div><div class="ls" style="opacity:1;color:#ff8a8a">${message}</div>`;
+    reloadOnVeilTap = tapToReload;
   }
+}
+
+function hideFatal(): void {
+  const loading = document.getElementById("loading");
+  if (loading) loading.style.display = "none";
+  reloadOnVeilTap = false;
 }
 
 // MSAA can't be changed after context creation. On dense phone screens the
@@ -101,6 +113,22 @@ const governor = new PerfGovernor(renderer, game.sunLight, (features) => {
 document.addEventListener("visibilitychange", () => {
   framePacer.setHidden(document.hidden);
   governor.resetTiming();
+});
+
+// A lost WebGL context is what a phone browser hands back when the tab runs
+// out of memory: three stops drawing, the canvas goes blank, and the DOM HUD
+// keeps updating over it as if nothing happened. Say so, and offer the one
+// recovery that works on iOS — a reload (the world caches make it a short
+// one). three already asks the browser for restoration; if it comes, resume.
+renderer.domElement.addEventListener("webglcontextlost", () => {
+  console.error("[crazy-waymo] WebGL context lost");
+  showFatal("The browser stopped the graphics (usually low memory). Tap to reload.", true);
+});
+renderer.domElement.addEventListener("webglcontextrestored", () => {
+  console.warn("[crazy-waymo] WebGL context restored");
+  hideFatal();
+  governor.resetTiming();
+  framePacer.invalidate();
 });
 
 if (import.meta.env.DEV) {

--- a/games/crazy-waymo/src/main.ts
+++ b/games/crazy-waymo/src/main.ts
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { setPauseHandlers } from "@repo/embed";
 
 import { FramePacer } from "./render/frame-pacer";
+import { hasReleasedArrays } from "./render/gpu-only-geometry";
 import { PerfGovernor } from "./render/perf-governor";
 import { PostPipeline } from "./render/post";
 import { setRenderCapabilities } from "./render/capabilities";
@@ -126,6 +127,14 @@ renderer.domElement.addEventListener("webglcontextlost", () => {
 });
 renderer.domElement.addEventListener("webglcontextrestored", () => {
   console.warn("[crazy-waymo] WebGL context restored");
+  // Restoration re-uploads every geometry from its heap array. Phones have
+  // released the static ones (render/gpu-only-geometry.ts), so the rebuilt
+  // city would be empty — a reload is the only complete recovery there.
+  if (hasReleasedArrays()) {
+    showFatal("Graphics restored — reloading…");
+    window.location.reload();
+    return;
+  }
   hideFatal();
   governor.resetTiming();
   framePacer.invalidate();

--- a/games/crazy-waymo/src/render/gpu-only-geometry.ts
+++ b/games/crazy-waymo/src/render/gpu-only-geometry.ts
@@ -1,0 +1,66 @@
+import * as THREE from "three";
+
+// Static geometry that lives on the GPU only. three keeps every vertex array
+// on the JS heap after it uploads it, so the shipped city costs its full size
+// TWICE — ~200 MB of typed arrays beside ~200 MB of GPU buffers on a phone.
+// Desktop shrugs; a phone browser counts both against one per-tab budget and
+// kills the WebGL context (blank canvas, HUD still alive) when it runs out.
+// The city never changes after construction, so the CPU copy has no reader
+// once the buffer exists.
+//
+// The array is swapped for an EMPTY typed array of the same type, not null:
+// BatchedMesh reads `index.array.BYTES_PER_ELEMENT` every frame to size its
+// multi-draw offsets, and `attribute.count` was fixed at construction, so an
+// empty array keeps every render-time read valid. A later `needsUpdate` on a
+// released attribute would re-upload nothing — the geometry must be final
+// before it is drawn (the callers build a mesh completely before attaching
+// it to the scene).
+//
+// The hook fires at upload time, per attribute, so a mesh culled off-screen
+// keeps its data until its first draw — replacing arrays eagerly would hand
+// the GPU an empty buffer for anything the camera had not seen yet.
+//
+// DEFERRED releases wait for one late CPU reader: the ceiling harvest
+// (world/solid-index.ts) walks the plain meshes' position arrays after the
+// title screen is up, i.e. after their first draw. Those attributes park in
+// `pending` when uploaded and are released together by
+// `releaseDeferredArrays()` once the harvest has run.
+
+const pending = new Set<THREE.BufferAttribute>();
+let armed = false;
+
+function release(attr: THREE.BufferAttribute): void {
+  // SAFETY: BufferAttribute only ever holds a TypedArray (its constructor
+  // and BatchedMesh's allocation both require one), so its constructor is
+  // one of the TypedArrayConstructor members.
+  const Ctor = attr.array.constructor as THREE.TypedArrayConstructor;
+  attr.array = new Ctor(0);
+  attr.updateRanges.length = 0;
+  attr.onUpload(() => {});
+}
+
+export function releaseArraysAfterUpload(
+  geometry: THREE.BufferGeometry,
+  options: { readonly deferred?: boolean } = {},
+): void {
+  const deferred = options.deferred === true;
+  const attrs: THREE.BufferAttribute[] = [];
+  for (const a of Object.values(geometry.attributes)) {
+    if (a instanceof THREE.BufferAttribute) attrs.push(a);
+  }
+  if (geometry.index) attrs.push(geometry.index);
+  for (const attr of attrs) {
+    attr.onUpload(() => {
+      if (deferred && !armed) pending.add(attr);
+      else release(attr);
+    });
+  }
+}
+
+/** The late CPU readers are done: drop every uploaded deferred array now, and
+ *  every later one the moment it uploads. */
+export function releaseDeferredArrays(): void {
+  armed = true;
+  for (const attr of pending) release(attr);
+  pending.clear();
+}

--- a/games/crazy-waymo/src/render/gpu-only-geometry.ts
+++ b/games/crazy-waymo/src/render/gpu-only-geometry.ts
@@ -18,16 +18,26 @@ import * as THREE from "three";
 //
 // The hook fires at upload time, per attribute, so a mesh culled off-screen
 // keeps its data until its first draw — replacing arrays eagerly would hand
-// the GPU an empty buffer for anything the camera had not seen yet.
+// the GPU an empty buffer for anything the camera had not seen yet. A mesh
+// that was ALREADY drawn when it is registered would never fire the hook
+// (three uploads a static buffer once), so registration bumps the attribute
+// version: an uploaded buffer re-uploads once and releases, a fresh one
+// uploads on its first draw as usual.
 //
 // DEFERRED releases wait for one late CPU reader: the ceiling harvest
 // (world/solid-index.ts) walks the plain meshes' position arrays after the
 // title screen is up, i.e. after their first draw. Those attributes park in
 // `pending` when uploaded and are released together by
 // `releaseDeferredArrays()` once the harvest has run.
+//
+// A RESTORED context re-uploads every geometry from its array. Once anything
+// here has been released that would draw an empty city, so the restore path
+// (main.ts) reloads the page instead when `hasReleasedArrays()` says so.
 
+const hooked = new WeakSet<THREE.BufferAttribute>();
 const pending = new Set<THREE.BufferAttribute>();
 let armed = false;
+let released = 0;
 
 function release(attr: THREE.BufferAttribute): void {
   // SAFETY: BufferAttribute only ever holds a TypedArray (its constructor
@@ -37,6 +47,7 @@ function release(attr: THREE.BufferAttribute): void {
   attr.array = new Ctor(0);
   attr.updateRanges.length = 0;
   attr.onUpload(() => {});
+  released++;
 }
 
 export function releaseArraysAfterUpload(
@@ -50,10 +61,14 @@ export function releaseArraysAfterUpload(
   }
   if (geometry.index) attrs.push(geometry.index);
   for (const attr of attrs) {
+    if (hooked.has(attr)) continue;
+    hooked.add(attr);
     attr.onUpload(() => {
       if (deferred && !armed) pending.add(attr);
       else release(attr);
     });
+    // Already on the GPU? One re-upload fires the hook (see header).
+    attr.needsUpdate = true;
   }
 }
 
@@ -63,4 +78,10 @@ export function releaseDeferredArrays(): void {
   armed = true;
   for (const attr of pending) release(attr);
   pending.clear();
+}
+
+/** True once any array is gone — a restored context can no longer rebuild
+ *  the scene from the heap. */
+export function hasReleasedArrays(): boolean {
+  return released > 0;
 }

--- a/games/crazy-waymo/src/scenes/game-scene.ts
+++ b/games/crazy-waymo/src/scenes/game-scene.ts
@@ -1148,19 +1148,23 @@ vec3 ocGerstner(vec2 p, float t) {
    */
   private async buildCeilingIndex(city: CityModel): Promise<void> {
     const t0 = performance.now();
-    const spans = await harvestCeilingSpans(
-      city.group,
-      city.terrain,
-      city.network,
-      () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
-    );
-    spans.push(...deckCeilings(city.getDecks()));
-    const index = new CeilingIndex(spans);
-    this.rig.setCeilings(index);
-    console.log(`[city] ceilings ${index.size} spans in ${Math.round(performance.now() - t0)}ms`);
-    // The last CPU reader of the static meshes' vertex arrays is done: phones
-    // drop the copies now (render/gpu-only-geometry.ts; no-op on desktop).
-    releaseDeferredArrays();
+    try {
+      const spans = await harvestCeilingSpans(
+        city.group,
+        city.terrain,
+        city.network,
+        () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
+      );
+      spans.push(...deckCeilings(city.getDecks()));
+      const index = new CeilingIndex(spans);
+      this.rig.setCeilings(index);
+      console.log(`[city] ceilings ${index.size} spans in ${Math.round(performance.now() - t0)}ms`);
+    } finally {
+      // The last CPU reader of the static meshes' vertex arrays is done (or
+      // gave up): phones drop the copies now (render/gpu-only-geometry.ts;
+      // no-op on desktop). Never let a failed harvest pin them.
+      releaseDeferredArrays();
+    }
   }
 
   private attachNightAndLife(city: CityModel): void {

--- a/games/crazy-waymo/src/scenes/game-scene.ts
+++ b/games/crazy-waymo/src/scenes/game-scene.ts
@@ -48,6 +48,7 @@ import { DayNight } from "../render/day-night";
 import { setGradeMotion } from "../render/grade";
 import { FarTerrain } from "../render/far-terrain";
 import { LandmarkSilhouettes } from "../render/landmark-silhouette";
+import { releaseDeferredArrays } from "../render/gpu-only-geometry";
 import { FULL_QUALITY, isCoarsePointer, type QualityFeatures } from "../render/quality";
 import { Sky } from "../render/sky";
 import {
@@ -1157,6 +1158,9 @@ vec3 ocGerstner(vec2 p, float t) {
     const index = new CeilingIndex(spans);
     this.rig.setCeilings(index);
     console.log(`[city] ceilings ${index.size} spans in ${Math.round(performance.now() - t0)}ms`);
+    // The last CPU reader of the static meshes' vertex arrays is done: phones
+    // drop the copies now (render/gpu-only-geometry.ts; no-op on desktop).
+    releaseDeferredArrays();
   }
 
   private attachNightAndLife(city: CityModel): void {

--- a/games/crazy-waymo/src/scenes/world-loader.ts
+++ b/games/crazy-waymo/src/scenes/world-loader.ts
@@ -115,7 +115,11 @@ function runWhenIdle(cb: () => void): void {
 
 // Work that must not land inside the load at all — an idle deadline can
 // still expire mid-build on a slow phone. Queued until the loading veil
-// drops, then handed to idle time.
+// drops, then handed to idle time. `hideLoading` only STARTS the veil's
+// 350 ms fade, and the title's first frames follow it; an idle slot between
+// those frames would still take a multi-second put(), so the hand-off waits
+// out the transition first.
+const AFTER_VEIL_MS = 1500;
 let loadFinished = false;
 const afterLoad: (() => void)[] = [];
 function runAfterLoad(cb: () => void): void {
@@ -123,8 +127,11 @@ function runAfterLoad(cb: () => void): void {
   else afterLoad.push(cb);
 }
 function flushAfterLoad(): void {
-  loadFinished = true;
-  for (const cb of afterLoad.splice(0)) runWhenIdle(cb);
+  const queued = afterLoad.splice(0);
+  setTimeout(() => {
+    loadFinished = true;
+    for (const cb of queued) runWhenIdle(cb);
+  }, AFTER_VEIL_MS);
 }
 
 function fromWorker(r: ParcelWorkerResponse): ParcelPlanResult {

--- a/games/crazy-waymo/src/scenes/world-loader.ts
+++ b/games/crazy-waymo/src/scenes/world-loader.ts
@@ -113,6 +113,20 @@ function runWhenIdle(cb: () => void): void {
   else setTimeout(cb, 8000);
 }
 
+// Work that must not land inside the load at all — an idle deadline can
+// still expire mid-build on a slow phone. Queued until the loading veil
+// drops, then handed to idle time.
+let loadFinished = false;
+const afterLoad: (() => void)[] = [];
+function runAfterLoad(cb: () => void): void {
+  if (loadFinished) runWhenIdle(cb);
+  else afterLoad.push(cb);
+}
+function flushAfterLoad(): void {
+  loadFinished = true;
+  for (const cb of afterLoad.splice(0)) runWhenIdle(cb);
+}
+
 function fromWorker(r: ParcelWorkerResponse): ParcelPlanResult {
   return { plans: r.plans, lots: r.lots, stats: r.stats, covered: new Set(r.covered) };
 }
@@ -147,8 +161,9 @@ function runParcelWorker(source: ArrayBuffer): Promise<ParcelPlanResult | null> 
         const r = ev.data;
         console.log(`[parcel-worker] planned ${r.plans.length} parcels in ${r.ms}ms`);
         // The put() serializes ~500k plan objects on the main thread — a
-        // multi-second block on a phone if it lands mid-load. Idle time only.
-        runWhenIdle(() => writeParcelPlanCache(bytes, r));
+        // multi-second block on a phone if it lands mid-load. After load,
+        // in idle time only.
+        runAfterLoad(() => writeParcelPlanCache(bytes, r));
         resolve(fromWorker(r));
         worker.terminate();
       };
@@ -518,6 +533,7 @@ async function finishLoad(
   deps.showTitle();
   deps.onPlayable();
   deps.hideLoading();
+  flushAfterLoad();
 }
 
 function storageGet(key: string): string | null {

--- a/games/crazy-waymo/src/scenes/world-loader.ts
+++ b/games/crazy-waymo/src/scenes/world-loader.ts
@@ -106,6 +106,13 @@ function cityEdited(): boolean {
   );
 }
 
+// Cache writes serialize large object graphs on the main thread. Never during
+// load; a browser without requestIdleCallback gets a plain delay instead.
+function runWhenIdle(cb: () => void): void {
+  if ("requestIdleCallback" in window) requestIdleCallback(cb, { timeout: 30000 });
+  else setTimeout(cb, 8000);
+}
+
 function fromWorker(r: ParcelWorkerResponse): ParcelPlanResult {
   return { plans: r.plans, lots: r.lots, stats: r.stats, covered: new Set(r.covered) };
 }
@@ -139,7 +146,9 @@ function runParcelWorker(source: ArrayBuffer): Promise<ParcelPlanResult | null> 
       worker.onmessage = (ev: MessageEvent<ParcelWorkerResponse>) => {
         const r = ev.data;
         console.log(`[parcel-worker] planned ${r.plans.length} parcels in ${r.ms}ms`);
-        writeParcelPlanCache(bytes, r);
+        // The put() serializes ~500k plan objects on the main thread — a
+        // multi-second block on a phone if it lands mid-load. Idle time only.
+        runWhenIdle(() => writeParcelPlanCache(bytes, r));
         resolve(fromWorker(r));
         worker.terminate();
       };
@@ -419,11 +428,7 @@ async function finishLoad(
   // The rest-cache write serializes ~100MB — idle time only, never at start.
   if (city.restCapture && !restState.fromBake) {
     const restCapture = city.restCapture;
-    const idle =
-      "requestIdleCallback" in window
-        ? (cb: () => void): void => void requestIdleCallback(cb, { timeout: 30000 })
-        : (cb: () => void): void => void setTimeout(cb, 8000);
-    idle(() => writeRestCache(restCapture));
+    runWhenIdle(() => writeRestCache(restCapture));
   }
   await paint();
 

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -13,8 +13,9 @@ import {
   setPropShadowPolicy,
   type PropShadowPolicy,
 } from "../render/prop-shadow";
-import { liveQuality } from "../render/quality";
+import { isCoarsePointer, liveQuality } from "../render/quality";
 import { renderCapabilities } from "../render/capabilities";
+import { releaseArraysAfterUpload } from "../render/gpu-only-geometry";
 import { compatiblePropBatch, type PropBatch, type PropInstance } from "./instanced-props";
 import {
   CHUNK,
@@ -1250,6 +1251,7 @@ export class CityModel {
       // reference for its last consumers; failed rebuilds keep this for retry.
       this.restPayload = null;
       console.log(`[city] rest rebuild ${Math.round(performance.now() - tR)}ms`);
+      this.releaseStaticGeometryAfterUpload();
       await tick(0.97);
       return;
     }
@@ -1262,7 +1264,36 @@ export class CityModel {
     console.log(
       `[city] phase2 ${Math.round(t1 - t0)}ms phase3 ${Math.round(performance.now() - t1)}ms`,
     );
+    this.releaseStaticGeometryAfterUpload();
     await tick(0.97);
+  }
+
+  /** Phones drop the CPU copies of static geometry once the GPU has them
+   *  (render/gpu-only-geometry.ts). Desktop keeps them: the editor and the
+   *  DEV `pick()` raycast read them, and memory is not the constraint there. */
+  private gpuOnlyGeometry(): boolean {
+    return isCoarsePointer() && !editorMode();
+  }
+
+  /** The plain static meshes — merged road chunks, terrain, freeways, piers,
+   *  landmarks — release their arrays DEFERRED: the ceiling harvest
+   *  (scenes/game-scene.ts buildCeilingIndex) still reads their positions after
+   *  the title is up, and arms the release when it finishes. Parcel cells are
+   *  transient (the streamer swaps and disposes them) and are left alone. */
+  private releaseStaticGeometryAfterUpload(): void {
+    if (!this.gpuOnlyGeometry()) return;
+    this.group.traverse((o) => {
+      if (!(o instanceof THREE.Mesh) || o.name.startsWith("parcel-")) return;
+      // Plain meshes only — BatchedMesh/InstancedMesh subclasses own their
+      // buffers differently and were handled at construction.
+      if (Object.getPrototypeOf(o) !== THREE.Mesh.prototype) return;
+      const geometry = o.geometry;
+      const attrs = [...Object.values(geometry.attributes), geometry.index];
+      for (const a of attrs) {
+        if (a instanceof THREE.BufferAttribute && a.usage !== THREE.StaticDrawUsage) return;
+      }
+      releaseArraysAfterUpload(geometry, { deferred: true });
+    });
   }
 
   private phase2!: () => Promise<void>;
@@ -1944,6 +1975,7 @@ export class CityModel {
     onProgress?: (f: number) => void,
   ): Promise<void> {
     const multiDraw = renderCapabilities().multiDraw;
+    const gpuOnly = this.gpuOnlyGeometry();
     // Instances stream on the fine STREAM_CELL grid, not the merge CHUNK grid
     // the caller used for road tiles — see STREAM_CELL.
     const nx = Math.ceil(WORLD_W / STREAM_CELL);
@@ -2150,6 +2182,15 @@ export class CityModel {
         batched.perObjectFrustumCulled = false;
       }
       const mesh = compatiblePropBatch(batched, bucket.items, multiDraw);
+      // Phones: the merged batch is final here, so its vertex arrays only
+      // exist on the GPU from the first draw on (render/gpu-only-geometry.ts).
+      // Desktop keeps the copies — the editor and the DEV `pick()` raycast
+      // read them, and memory is not the constraint there. The instanced
+      // fallback shares ModelCache template geometry and is left alone.
+      if (gpuOnly) {
+        if (mesh instanceof THREE.BatchedMesh) releaseArraysAfterUpload(mesh.geometry);
+        else mesh.releaseCpuGeometry();
+      }
       this.group.add(mesh);
       this.batches.push({ mesh, chunkIds });
     }

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -1236,6 +1236,9 @@ export class CityModel {
     await tick(0.87);
     this.buildPhase1();
     console.log(`[city] phase1 ${Math.round(performance.now() - t0)}ms`);
+    // Hook the phase-1 meshes before the loader attaches the group: the
+    // title camera draws them all through the rest of the load.
+    this.releaseStaticGeometryAfterUpload();
     await tick(0.95);
   }
 

--- a/games/crazy-waymo/src/world/instanced-props.ts
+++ b/games/crazy-waymo/src/world/instanced-props.ts
@@ -1,5 +1,7 @@
 import * as THREE from "three";
 
+import { releaseArraysAfterUpload } from "../render/gpu-only-geometry";
+
 export type PropInstance = {
   readonly geo: THREE.BufferGeometry;
   readonly matrix: THREE.Matrix4;
@@ -217,6 +219,13 @@ export class InstancedProps extends THREE.Group {
       color.addUpdateRange(slot * 3, 3);
       color.needsUpdate = true;
     }
+  }
+
+  /** Drop the CPU copy of the unique-geometry batch once the GPU has it
+   *  (render/gpu-only-geometry.ts). The packed groups share ModelCache
+   *  template geometry with everything else and keep theirs. */
+  releaseCpuGeometry(): void {
+    if (this.singles) releaseArraysAfterUpload(this.singles.geometry);
   }
 
   dispose(): void {


### PR DESCRIPTION
## Problem

On a phone, crazy-waymo.vibedgames.com shows a pure white canvas (every sampled pixel is 255/255/255) while the DOM HUD, minimap and speedometer keep updating. That is what a killed WebGL context looks like: three stops drawing, the browser paints nothing behind the HUD. The phone path was carrying ~530 MB of JS heap plus ~120 MB of GPU buffers, with every static vertex array kept on the heap after three had uploaded it — a phone browser counts both against one tab budget.

Headless Chromium with iPhone emulation renders the phone path fine (before and after), so the failure is device-side and could not be reproduced here. The changes cut what the phone holds and make the failure visible instead of silent.

## Changes

- **`render/gpu-only-geometry.ts`** (new): once the GPU has a static attribute, swap its array for an empty typed array of the same type. BatchedMesh reads `index.array.BYTES_PER_ELEMENT` every frame and `attribute.count` is fixed at construction, so render-time reads stay valid. The hook fires at upload, so a mesh the camera has not seen keeps its data.
- **`world/city.ts`**: on phones (coarse pointer, not the editor) the merged prop batches release at upload; the plain static meshes (road chunks, terrain, freeways, piers, landmarks) release deferred until the ceiling harvest has run, since it is their last CPU reader. Desktop keeps every copy (the editor and the DEV `pick()` raycast read them).
- **`world/instanced-props.ts`**: the no-multi-draw fallback releases its unique-geometry batch the same way; packed groups share ModelCache template geometry and are left alone.
- **`scenes/game-scene.ts`**: arms the deferred release after `buildCeilingIndex`.
- **`main.ts`**: `webglcontextlost` shows the loading veil with "The browser stopped the graphics (usually low memory). Tap to reload."; `webglcontextrestored` hides it and resumes.
- **`scenes/world-loader.ts`**: the parcel-plan IndexedDB write moves to idle time (shared `runWhenIdle` with the rest cache). Its `put()` serialized ~500k plan objects on the main thread in the middle of load.

## Verification

- `tsc --noEmit`, oxlint (no errors), oxfmt on the game; `pnpm test` in `games/crazy-waymo`: 382 passed.
- Emulated iPhone 14 Pro against the dev server: scene vertex arrays 122.9 MB → 93.3 MB right after load (the prop batches release immediately; road chunks release as they are first drawn), rendering identical.
- Forced `WEBGL_lose_context.loseContext()` shows the veil with the reload prompt; `restoreContext()` hides it and rendering continues.
- Desktop emulation: arrays stay resident, no console errors.
- Root `pnpm verify` could not run in this container (turbo fails to spawn native binaries for gamepad/multiplayer/asset-tools with "Exec format error"); lint and format were run at the root directly.

## Not addressed

Load time is dominated by the ~27 MB of already-gzipped world bins plus main-thread city assembly, neither of which this touches. The game deploys via `vg deploy ./dist`, not the platform workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJDkZ2hipbVem56t6Dn7A2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJDkZ2hipbVem56t6Dn7A2)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On phones, the game now frees the CPU copies of static vertex arrays after they upload to the GPU, and lost WebGL contexts show a tap-to-reload prompt instead of a silent blank canvas.

**Details**
- New `gpu-only-geometry.ts` swaps static attribute arrays for empty typed arrays after upload; `BatchedMesh` render-time reads stay valid.
- Phase-1 meshes are hooked before the loader attaches the group, and a version bump re-uploads already-uploaded buffers so their arrays release too.
- Phones release merged prop batches immediately; plain static meshes release after the ceiling harvest, their last CPU reader. Desktop keeps all copies.
- A restored context reloads the page once any array was released, since a rebuild would draw an empty city; it resumes rendering only on desktop.
- The parcel-plan IndexedDB write waits out the loading veil's fade transition, then runs in idle time instead of blocking the main thread mid-load.

<sup>Written for commit f180bb8d868a684f703feeeb52748196bcd31bae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

