### PR TITLE
feat(battle-arena): port four spell effects from the extended VFX sandbox

### DIFF
--- a/games/battle-arena/src/data/champions.ts
+++ b/games/battle-arena/src/data/champions.ts
@@ -840,7 +840,7 @@ export const CHAMPIONS: ChampDef[] = [
           radius: [3.2, 3.4, 3.6, 3.8],
           duration: [4, 4, 4, 4],
         },
-        desc: "Spill the cauldron — the brew burns and slows all who wade in.",
+        desc: "Spill the cauldron — acid eats the floor, burning and slowing all who wade in.",
       }),
       E: ab({
         key: "E",
@@ -866,7 +866,7 @@ export const CHAMPIONS: ChampDef[] = [
         manaCost: [0, 0, 0],
         cooldown: [80, 70, 60],
         values: { radius: [4, 4.5, 5], duration: [2.0, 2.4, 2.8], slow: [40, 40, 40] },
-        desc: "Hex the ground — everyone caught becomes a harmless mushroom.",
+        desc: "Tear a void open over the ground — everyone it swallows becomes a harmless mushroom.",
       }),
       DASH: ab({
         key: "DASH",

--- a/games/battle-arena/src/render/fx-pillar.ts
+++ b/games/battle-arena/src/render/fx-pillar.ts
@@ -1,0 +1,720 @@
+// The column of judgment — a shaft of light standing on the mark, a
+// four-pointed star welded to its head, and two counter-tilted halo rings
+// turning about it. Aurelius' Consecrating Smite lands in this.
+//
+// Ported from the Elemental Sandbox VFX sandbox (MIT, Copyright (c) 2026
+// mohamedachrefelouafi) — https://github.com/achrefelouafi/LinearAbiltyCastingExtendedThreeJS
+// (the "Celestial Rend"), re-scaled for our arena: the sandbox's column is
+// thirty metres tall on a five-metre footprint; ours has to sit inside a
+// three-metre stun zone under a camera a fifth as far away, so every dimension
+// is a multiple of the zone radius and the flute count is roughly halved.
+//
+// Why the column is shaded on N·V and not on a fresnel: a beam of light is a
+// VOLUME, and what the eye reads as its brightness is how much of that volume
+// the ray crossed — longest through the middle of the silhouette, nothing at
+// the edges. A fresnel is bright at the rim and hollow in the middle, which is
+// what a soap bubble looks like, not a searchlight. (Our older fx-beam pillar
+// already folds the same rod-weighting in; this one adds the flutes, the skirt
+// where it meets the stone, and the star + rings on top.)
+//
+// Why the star is not a texture: authored as a polar field it is three raised
+// cosines summed into a reach, with a hard boundary and a shaded interior —
+// concave-sided points that stay sharp at any size, with bloom on top.
+//
+// All three pieces are built in WORLD space by their vertex shaders (the
+// column and the star never leave the origin), so the pool never touches a
+// vertex: strike() writes a centre and a footprint, and update() scrubs one
+// clock through every uniform.
+import * as THREE from "three";
+import { NOISE_GLSL } from "./fx-noise";
+
+const POOL = 3;
+const CLIMB_ROWS = 26; // samples up the shaft
+const AROUND_COLS = 48; // ...and around it
+
+/** Every dimension below is × the footprint radius unless it says metres. */
+const COLUMN = {
+  height: 5.2, // the shaft, × footprint — it leaves the top of the frame on purpose
+  radius: 0.3, // the shaft
+  skirt: 1.1, // how far it flares where it meets the stone
+  skirtPower: 4.5, // ... and how fast that closes with height
+  topFlare: 1.25, // how much wider it is at the top
+  flarePower: 1.6,
+  wobble: 0.08, // noise on the barrel, × its radius
+  wobbleScale: 1.1,
+  wobbleSpeed: 1.2,
+  spin: 0.05, // revolutions/second the barrel turns
+  // The star and the rings sit LOW — a unit and a half off the floor, not the
+  // sandbox's 40% of a thirty-metre shaft. Our camera looks steeply down at
+  // the arena, and anything higher than a few metres is simply above the top
+  // of the frame.
+  starSeat: 0.95, // where the star hangs, × footprint (metres up)
+  starSize: 0.75, // its half-extent, × footprint
+  haloOuter: 1.05, // the rings' outer edge, × footprint
+  haloSeat: 0.87, // where the band sits inside that
+  haloBand: 0.055, // ... and how deep it is
+  haloSecond: 0.9, // the second ring, × the first
+  haloTilt: 0.34, // radians each leans, opposite ways
+  haloSpin: 0.11, // revolutions/second, opposite ways
+  haloLift: 0.3, // metres apart they sit, × footprint
+} as const;
+
+/** The sequence, in seconds since the strike. */
+const BEATS = {
+  rise: 0.26, // the beam's front reaching the top
+  starDelay: 0.1,
+  starTime: 0.36,
+  haloDelay: 0.14,
+  haloStagger: 0.09,
+  haloTime: 0.4,
+  hold: 0.95, // full brightness until here
+  life: 1.6, // gone
+  pulseRate: 1.4, // the toll envelope
+} as const;
+
+const TAU = Math.PI * 2;
+
+// ── the column ──────────────────────────────────────────────────────────────
+
+const PILLAR_VERT = /* glsl */ `
+#define TAU 6.283185307179586
+uniform float uTime;
+uniform vec3  uCentre;
+uniform float uRadius;
+uniform float uHeight;
+uniform float uSeed;
+
+varying float vClimb;
+varying float vAround;
+varying vec3  vNormalW;
+varying vec3  vWorld;
+
+${NOISE_GLSL}
+
+void main() {
+  float t = position.x; // 0 at the floor, 1 at the top of the shaft
+  float a = position.y; // 0..1 once around
+  float angle = a * TAU + uTime * ${COLUMN.spin.toFixed(3)} * TAU;
+
+  // The profile: a wide skirt where it meets the stone, closing hard into the
+  // shaft, then opening slowly with height. The skirt is not decoration — it
+  // is what makes the column look like it is STANDING ON the mark rather than
+  // passing through the floor.
+  float skirt = ${COLUMN.skirt.toFixed(3)} * pow(1.0 - t, ${COLUMN.skirtPower.toFixed(3)});
+  float shaft = mix(1.0, ${COLUMN.topFlare.toFixed(3)}, pow(t, ${COLUMN.flarePower.toFixed(3)}));
+  float wobble = snoise(vec3(cos(angle) * ${COLUMN.wobbleScale.toFixed(3)}, sin(angle) * ${COLUMN.wobbleScale.toFixed(3)},
+                             t * ${(COLUMN.wobbleScale * 2).toFixed(3)} - uTime * ${COLUMN.wobbleSpeed.toFixed(3)} + uSeed)) * ${COLUMN.wobble.toFixed(3)};
+  float radius = max(0.02, uRadius * (shaft + skirt + wobble));
+
+  vec3 world = uCentre + vec3(cos(angle), 0.0, sin(angle)) * radius;
+  world.y += t * uHeight;
+
+  vClimb = t;
+  vAround = a;
+  vWorld = world;
+  // Radial — the surface normal of a cylinder everywhere but the skirt, and
+  // the skirt is short enough that the error never shows.
+  vNormalW = vec3(cos(angle), 0.0, sin(angle));
+  gl_Position = projectionMatrix * viewMatrix * vec4(world, 1.0);
+}`;
+
+const PILLAR_FRAG = /* glsl */ `
+#define PI 3.141592653589793
+uniform float uTime;
+uniform float uGrown;
+uniform float uFront;
+uniform float uFade;
+uniform float uSeed;
+uniform float uCharge;
+uniform float uPulse;
+uniform vec3  uColorCore;
+uniform vec3  uColorBody;
+uniform vec3  uColorEdge;
+uniform vec3  uColorCool;
+
+varying float vClimb;
+varying float vAround;
+varying vec3  vNormalW;
+varying vec3  vWorld;
+
+${NOISE_GLSL}
+
+void main() {
+  // The beam races up out of the mark. Nothing above the front exists yet.
+  float live = 1.0 - smoothstep(uGrown - 0.04, uGrown + 0.02, vClimb);
+  if (live < 0.003) discard;
+
+  vec3 V = normalize(cameraPosition - vWorld);
+  float ndv = abs(dot(normalize(vNormalW), V));
+
+  // How much beam this ray crossed: a power of |N.V|, NOT of 1 - |N.V| — the
+  // chord through a cylinder is longest through the middle of the silhouette.
+  float body = pow(ndv, 1.3);
+  // ... and the white-hot filament down the axis: the same term run much harder.
+  float core = pow(ndv, 9.0) * 0.35;
+  // The caustic boundary. Small, and only here so the shaft has an edge.
+  float rim = pow(1.0 - ndv, 2.2) * 0.35;
+
+  // Flutes combed up the barrel, drifting slowly around it, with streams of
+  // light pouring up through them in the barrel's own cylindrical space.
+  float flute = pow(abs(sin((vAround + uTime * 0.035) * PI * 12.0)), 0.55);
+  float stream = fbm2(vec3(vAround * 6.0, vClimb * 3.0 - uTime * 1.6, uSeed));
+  stream = smoothstep(-0.3, 0.7, stream);
+  float combed = mix(1.0, mix(flute, 1.0, 0.35) * (0.45 + 0.75 * stream), 0.6);
+
+  // Top: the beam does not end, it loses itself. Bottom: it piles up on the
+  // stone, which is where the ability is actually happening.
+  float top = 1.0 - smoothstep(0.58, 1.0, vClimb);
+  float foot = 1.0 + 0.7 * exp(-vClimb / 0.12);
+  // The hot leading edge while it is still climbing.
+  float front = exp(-pow((vClimb - uGrown) / 0.055, 2.0)) * uFront;
+
+  float beat = 1.0 + uPulse * 0.35 + uCharge * 0.5;
+  float energy = (body * combed + core) * live * top * foot * beat;
+
+  // Gold in its mass with blue-white light escaping off its edges.
+  vec3 color = mix(uColorBody, uColorCore, clamp(core * 1.4 + front, 0.0, 1.0));
+  color = mix(color, uColorEdge, smoothstep(0.35, 1.0, vClimb) * 0.45);
+  color *= energy;
+  color += uColorCool * rim * live * top * beat;
+  color += uColorCore * front * 1.4 * live;
+  // The sandbox runs this at 0.36 under a gentler bloom; under ours anything
+  // past ~1 in the additive sum turns the shaft into a white slab with the
+  // subject lost inside it, so the whole thing is held well under the bloom
+  // threshold and the star is left to carry the hot spot.
+  color *= 0.22 * uFade;
+
+  float alpha = clamp(energy * 0.55 + rim * 0.3 + front * 0.5, 0.0, 1.0) * uFade;
+  if (alpha < 0.003) discard;
+  color /= 1.0 + color * 0.25;
+  gl_FragColor = vec4(color, alpha);
+}`;
+
+// ── the star at its head ────────────────────────────────────────────────────
+
+const STAR_VERT = /* glsl */ `
+uniform vec3  uCentre;
+uniform float uSize;
+varying vec2 vLocal;
+void main() {
+  // Billboarded off the camera basis, kept UPRIGHT in screen space on purpose:
+  // the star has a long vertical axis and a shorter horizontal one, and a star
+  // that rolls with the camera loses that read immediately.
+  vec3 right = vec3(viewMatrix[0][0], viewMatrix[1][0], viewMatrix[2][0]);
+  vec3 up    = vec3(viewMatrix[0][1], viewMatrix[1][1], viewMatrix[2][1]);
+  vLocal = position.xy * 2.0;
+  vec3 world = uCentre + (right * position.x + up * position.y) * uSize * 2.0;
+  gl_Position = projectionMatrix * viewMatrix * vec4(world, 1.0);
+}`;
+
+const STAR_FRAG = /* glsl */ `
+#define TAU 6.283185307179586
+uniform float uTime;
+uniform float uSeed;
+uniform float uFade;
+uniform float uCharge;
+uniform float uPulse;
+uniform vec3  uColorCore;
+uniform vec3  uColorBody;
+uniform vec3  uColorEdge;
+uniform vec3  uColorCool;
+varying vec2 vLocal;
+
+${NOISE_GLSL}
+
+void main() {
+  vec2 p = vLocal;
+  float d = length(p);
+  if (d > 1.35) discard;
+  float inv = 1.0 / max(d, 1e-4);
+  float c = p.x * inv;
+  float s = p.y * inv;
+
+  // Three raised cosines summed: a long vertical pair, a shorter horizontal
+  // pair, four short diagonals. Each is concave-sided by construction, which
+  // is what a polygonal star is not.
+  float reach = 1.0  * pow(abs(s), 7.0)
+              + 0.72 * pow(abs(c), 11.0)
+              + 0.1  * pow(abs(2.0 * s * c), 7.0);
+
+  // The fine spray between them: many short needles, eaten by noise so they
+  // are not a comb, turning slowly against the star itself.
+  float ang = atan(p.y, p.x) + uTime * 0.015 * TAU;
+  float needle = pow(abs(sin(ang * 17.0)), 9.0);
+  needle *= 0.35 + 0.65 * (0.5 + 0.5 * snoise(vec3(cos(ang) * 3.0, sin(ang) * 3.0, uSeed + uTime * 0.25)));
+  reach += needle * 0.09;
+
+  float flicker = 1.0 + 0.12 * snoise(vec3(uSeed, uTime * 2.6, 0.0));
+  float beat = (1.0 + uPulse * 0.6 + uCharge * 0.9) * flicker;
+
+  // A hard boundary with a soft interior, not a bare exponential: exp(-d/reach)
+  // never reaches zero, so the concave sides between the points never resolve
+  // into a silhouette. The beat is deliberately NOT in the reach — a star
+  // whose reach breathes grows past its quad and squares off at the edge.
+  float span = max(reach * 0.86, 1e-4);
+  float rays = pow(clamp(1.0 - d / span, 0.0, 1.0), 1.5);
+  float halo = exp(-d / max(span * 0.35, 1e-4)) * 0.35;
+  float window = 1.0 - smoothstep(0.85, 1.2, d);
+  float core = exp(-(d * d) / 0.0036) * 0.9;
+
+  // The thin circle struck through it.
+  float f = d - 0.5;
+  float g = max(fwidth(f), 1e-7);
+  float ring = (1.0 - smoothstep(0.0, max(0.008, g), abs(f))) * 0.3;
+
+  float energy = (rays + halo + core + ring) * beat * window;
+  if (energy < 0.004) discard;
+
+  // Warm through the body, near-white in the core, and a cold fringe out at
+  // the extreme tips — the one place the gold turns blue.
+  vec3 color = mix(uColorBody, uColorCore, clamp(core + rays * 0.35, 0.0, 1.0));
+  color = mix(color, uColorEdge, smoothstep(0.12, 0.5, d));
+  color = mix(color, uColorCool, smoothstep(0.45, 0.95, d) * 0.7);
+  color *= energy * 0.7 * uFade;
+
+  float alpha = clamp(energy, 0.0, 1.0) * uFade;
+  color /= 1.0 + color * 0.22;
+  gl_FragColor = vec4(color, alpha);
+}`;
+
+// ── the halo rings ──────────────────────────────────────────────────────────
+
+const HALO_VERT = /* glsl */ `
+uniform float uOuter;
+varying vec2 vLocal;
+void main() {
+  // The annulus arrives as a unit ring; the pool tilts and turns the mesh, so
+  // everything below works in the ring's own plane and never has to know
+  // which way it is leaning.
+  vLocal = position.xy * uOuter;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position.xy * uOuter, 0.0, 1.0);
+}`;
+
+const HALO_FRAG = /* glsl */ `
+#define TAU 6.283185307179586
+uniform float uTime;
+uniform float uSeed;
+uniform float uFade;
+uniform float uCharge;
+uniform float uPulse;
+uniform float uSeat;
+uniform float uBand;
+uniform float uOpen;
+uniform vec3  uColorCore;
+uniform vec3  uColorBody;
+uniform vec3  uColorCool;
+varying vec2 vLocal;
+
+${NOISE_GLSL}
+
+/** Any field, stroked as a line of constant apparent width. */
+float lineAA(float f, float w) {
+  float g = max(fwidth(f), 1e-7);
+  float px = abs(f) / g;
+  float want = w / g;
+  float ww = max(want, 1.0);
+  return (1.0 - smoothstep(0.0, ww, px)) * (want / ww);
+}
+
+void main() {
+  float r = length(vLocal);
+  float a = atan(vLocal.y, vLocal.x);
+
+  // Across the band: a soft profile with a hot line down its middle.
+  float d = r - uSeat;
+  float across = 1.0 - smoothstep(0.0, max(uBand, 1e-4), abs(d));
+  if (across < 0.003) discard;
+  float body = pow(across, 1.6);
+
+  // The two rails that fence it — what makes a ring read as machined rather
+  // than as a smear of light at this radius.
+  float rails = lineAA(abs(d) - uBand * 0.86, 0.03) * 1.2;
+
+  // Dashes cut around it, drifting slowly.
+  float turn = a / TAU + uTime * 0.03;
+  float cell = fract(turn * 44.0);
+  float dash = smoothstep(0.0, 0.08, cell) * (1.0 - smoothstep(0.5, 0.58, cell));
+  float dashed = mix(1.0, dash, 0.55);
+
+  // Glyph beads seated on the band at a lower count — a handful of bright
+  // nodes, not an even necklace.
+  float gcell = fract(turn * 4.0);
+  float bead = 1.0 - smoothstep(0.0, 0.012, min(gcell, 1.0 - gcell));
+  bead *= (1.0 - smoothstep(0.0, uBand * 0.9, abs(d))) * 0.9;
+
+  // The lit limb: one side brighter than the other, and that side travels,
+  // which is what says the thing is turning at speed.
+  float sweep = pow(max(0.0, cos(a - uTime * 0.22 * TAU)), 2.4) * 1.1;
+  float grain = 1.0 + (0.5 + 0.5 * snoise(vec3(cos(a) * 3.0, sin(a) * 3.0, uTime * 0.3 + uSeed)) - 0.5) * 0.35;
+
+  // The ring writes itself on from one bearing outward, so it snaps into
+  // existence as an arc rather than appearing whole.
+  float written = smoothstep(0.0, 0.14, uOpen - fract((a + 3.14159265) / TAU));
+  written = max(written, step(0.999, uOpen));
+
+  float beat = 1.0 + uPulse * 0.5 + uCharge * 0.8;
+  float energy = (body * dashed * (1.0 + sweep) + rails + bead * 1.5) * grain * written * beat;
+  if (energy < 0.004) discard;
+
+  vec3 color = mix(uColorBody, uColorCore, clamp(rails + bead + sweep * 0.4, 0.0, 1.0));
+  color = mix(color, uColorCool, smoothstep(0.6, 1.0, 1.0 - across) * 0.5);
+  color *= energy * 0.42 * uFade;
+
+  float alpha = clamp(energy, 0.0, 1.0) * 0.7 * uFade;
+  color /= 1.0 + color * 0.2;
+  gl_FragColor = vec4(color, alpha);
+}`;
+
+type PillarUniforms = {
+  uTime: { value: number };
+  uCentre: { value: THREE.Vector3 };
+  uRadius: { value: number };
+  uHeight: { value: number };
+  uSeed: { value: number };
+  uGrown: { value: number };
+  uFront: { value: number };
+  uFade: { value: number };
+  uCharge: { value: number };
+  uPulse: { value: number };
+  uColorCore: { value: THREE.Color };
+  uColorBody: { value: THREE.Color };
+  uColorEdge: { value: THREE.Color };
+  uColorCool: { value: THREE.Color };
+};
+
+type StarUniforms = {
+  uTime: { value: number };
+  uCentre: { value: THREE.Vector3 };
+  uSize: { value: number };
+  uSeed: { value: number };
+  uFade: { value: number };
+  uCharge: { value: number };
+  uPulse: { value: number };
+  uColorCore: { value: THREE.Color };
+  uColorBody: { value: THREE.Color };
+  uColorEdge: { value: THREE.Color };
+  uColorCool: { value: THREE.Color };
+};
+
+type HaloUniforms = {
+  uTime: { value: number };
+  uOuter: { value: number };
+  uSeat: { value: number };
+  uBand: { value: number };
+  uOpen: { value: number };
+  uSeed: { value: number };
+  uFade: { value: number };
+  uCharge: { value: number };
+  uPulse: { value: number };
+  uColorCore: { value: THREE.Color };
+  uColorBody: { value: THREE.Color };
+  uColorCool: { value: THREE.Color };
+};
+
+type Halo = { mesh: THREE.Mesh; uni: HaloUniforms; dir: number };
+
+type Pillar = {
+  column: THREE.Mesh;
+  star: THREE.Mesh;
+  halos: [Halo, Halo];
+  uni: PillarUniforms;
+  starUni: StarUniforms;
+  t: number; // seconds since the strike
+  live: boolean;
+  footprint: number;
+  height: number;
+  starY: number; // world height of the star (and the rings' seat)
+};
+
+export type PillarOpts = {
+  /** The four-stop palette: core (near-white), body, edge, cool fringe. */
+  colors?: { core: number; body: number; edge: number; cool: number };
+};
+
+const GOLD = { core: 0xfffdf2, body: 0xffd489, edge: 0xffb254, cool: 0xbcd8ff } as const;
+
+/**
+ * A grid of quads in parameter space: (x = along, y = around), z unused.
+ * The vertex shader turns every pair into a world position.
+ */
+function parameterGrid(rows: number, columns: number): THREE.BufferGeometry {
+  const positions = new Float32Array(rows * columns * 3);
+  let v = 0;
+  for (let i = 0; i < rows; i++) {
+    for (let j = 0; j < columns; j++) {
+      positions[v++] = i / (rows - 1);
+      positions[v++] = j / (columns - 1);
+      positions[v++] = 0;
+    }
+  }
+  const indices = new Uint16Array((rows - 1) * (columns - 1) * 6);
+  let k = 0;
+  for (let i = 0; i < rows - 1; i++) {
+    for (let j = 0; j < columns - 1; j++) {
+      const a = i * columns + j;
+      const b = a + columns;
+      indices[k++] = a;
+      indices[k++] = b;
+      indices[k++] = a + 1;
+      indices[k++] = b;
+      indices[k++] = b + 1;
+      indices[k++] = a + 1;
+    }
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geo.setIndex(new THREE.BufferAttribute(indices, 1));
+  // Placed in world space by the shader — its own bounds mean nothing.
+  geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e4);
+  return geo;
+}
+
+const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
+/** Linear ramp 0→1 over [start, start + dur]. */
+const ramp = (t: number, start: number, dur: number) => clamp01((t - start) / Math.max(dur, 1e-3));
+const easeOut = (k: number) => 1 - (1 - k) * (1 - k);
+
+/** Pooled columns of light. Four draw calls each: shaft, star, two rings. */
+export class PillarPool {
+  private pillars: Pillar[] = [];
+  private columnGeo = parameterGrid(CLIMB_ROWS, AROUND_COLS);
+  private starGeo = new THREE.PlaneGeometry(1, 1);
+  private haloGeo = new THREE.RingGeometry(0.52, 1.0, 72, 1);
+
+  constructor(
+    private scene: THREE.Scene,
+    clock: { value: number },
+  ) {
+    for (let i = 0; i < POOL; i++) {
+      const uni: PillarUniforms = {
+        uTime: clock,
+        uCentre: { value: new THREE.Vector3() },
+        uRadius: { value: 1 },
+        uHeight: { value: 10 },
+        uSeed: { value: 0 },
+        uGrown: { value: 0 },
+        uFront: { value: 1 },
+        uFade: { value: 1 },
+        uCharge: { value: 0 },
+        uPulse: { value: 0 },
+        uColorCore: { value: new THREE.Color(GOLD.core) },
+        uColorBody: { value: new THREE.Color(GOLD.body) },
+        uColorEdge: { value: new THREE.Color(GOLD.edge) },
+        uColorCool: { value: new THREE.Color(GOLD.cool) },
+      };
+      const column = new THREE.Mesh(
+        this.columnGeo,
+        new THREE.ShaderMaterial({
+          uniforms: uni,
+          vertexShader: PILLAR_VERT,
+          fragmentShader: PILLAR_FRAG,
+          transparent: true,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+          side: THREE.DoubleSide,
+        }),
+      );
+      column.frustumCulled = false;
+      column.visible = false;
+      column.renderOrder = 6;
+      this.scene.add(column);
+
+      const starUni: StarUniforms = {
+        uTime: clock,
+        uCentre: { value: new THREE.Vector3() },
+        uSize: { value: 1 },
+        uSeed: { value: 0 },
+        uFade: { value: 1 },
+        uCharge: { value: 0 },
+        uPulse: { value: 0 },
+        uColorCore: { value: new THREE.Color(GOLD.core) },
+        uColorBody: { value: new THREE.Color(GOLD.body) },
+        uColorEdge: { value: new THREE.Color(GOLD.edge) },
+        uColorCool: { value: new THREE.Color(GOLD.cool) },
+      };
+      const star = new THREE.Mesh(
+        this.starGeo,
+        new THREE.ShaderMaterial({
+          uniforms: starUni,
+          vertexShader: STAR_VERT,
+          fragmentShader: STAR_FRAG,
+          transparent: true,
+          depthWrite: false,
+          // Off on purpose: the star is the brightest thing in the ability and
+          // sits inside the column's own volume. Tested against the shaft it
+          // would be punched through by whichever wall was nearer the camera.
+          depthTest: false,
+          blending: THREE.AdditiveBlending,
+          side: THREE.DoubleSide,
+        }),
+      );
+      star.frustumCulled = false;
+      star.visible = false;
+      star.renderOrder = 7;
+      this.scene.add(star);
+
+      const mkHalo = (dir: number): Halo => {
+        const hu: HaloUniforms = {
+          uTime: clock,
+          uOuter: { value: 1 },
+          uSeat: { value: 0.87 },
+          uBand: { value: 0.1 },
+          uOpen: { value: 0 },
+          uSeed: { value: 0 },
+          uFade: { value: 1 },
+          uCharge: { value: 0 },
+          uPulse: { value: 0 },
+          uColorCore: { value: new THREE.Color(GOLD.core) },
+          uColorBody: { value: new THREE.Color(GOLD.body) },
+          uColorCool: { value: new THREE.Color(GOLD.cool) },
+        };
+        const mesh = new THREE.Mesh(
+          this.haloGeo,
+          new THREE.ShaderMaterial({
+            uniforms: hu,
+            vertexShader: HALO_VERT,
+            fragmentShader: HALO_FRAG,
+            transparent: true,
+            depthWrite: false,
+            depthTest: false,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide,
+          }),
+        );
+        mesh.frustumCulled = false;
+        mesh.visible = false;
+        mesh.renderOrder = 7;
+        this.scene.add(mesh);
+        return { mesh, uni: hu, dir };
+      };
+
+      this.pillars.push({
+        column,
+        star,
+        halos: [mkHalo(1), mkHalo(-1)],
+        uni,
+        starUni,
+        t: 0,
+        live: false,
+        footprint: 1,
+        height: 10,
+        starY: 0,
+      });
+    }
+  }
+
+  /**
+   * Stand a column up on (x, groundY, z) over a zone of radius `footprint`.
+   * Everything scales off the footprint, so a rank-4 smite is a bigger column
+   * for free.
+   */
+  strike(x: number, groundY: number, z: number, footprint: number, opts: PillarOpts = {}): void {
+    const p = this.pillars.find((e) => !e.live);
+    if (!p) return; // saturated — drop
+    const colors = opts.colors ?? GOLD;
+    p.live = true;
+    p.t = 0;
+    p.footprint = footprint;
+    p.height = COLUMN.height * footprint;
+    p.starY = groundY + COLUMN.starSeat * footprint;
+    const seed = Math.random() * 100;
+
+    p.uni.uCentre.value.set(x, groundY, z);
+    p.uni.uRadius.value = COLUMN.radius * footprint;
+    p.uni.uHeight.value = p.height;
+    p.uni.uSeed.value = seed;
+    p.uni.uColorCore.value.setHex(colors.core);
+    p.uni.uColorBody.value.setHex(colors.body);
+    p.uni.uColorEdge.value.setHex(colors.edge);
+    p.uni.uColorCool.value.setHex(colors.cool);
+
+    p.starUni.uCentre.value.set(x, p.starY, z);
+    p.starUni.uSeed.value = seed;
+    p.starUni.uColorCore.value.setHex(colors.core);
+    p.starUni.uColorBody.value.setHex(colors.body);
+    p.starUni.uColorEdge.value.setHex(colors.edge);
+    p.starUni.uColorCool.value.setHex(colors.cool);
+
+    const outer = COLUMN.haloOuter * footprint;
+    for (const [i, h] of p.halos.entries()) {
+      const scale = i === 0 ? 1 : COLUMN.haloSecond;
+      h.uni.uOuter.value = outer * scale;
+      h.uni.uSeat.value = outer * scale * COLUMN.haloSeat;
+      h.uni.uBand.value = outer * scale * COLUMN.haloBand;
+      h.uni.uSeed.value = seed + i * 7.3;
+      h.uni.uOpen.value = 0;
+      h.uni.uColorCore.value.setHex(colors.core);
+      h.uni.uColorBody.value.setHex(colors.body);
+      h.uni.uColorCool.value.setHex(colors.cool);
+      h.mesh.position.set(x, p.starY + (i === 0 ? 0.5 : -0.5) * COLUMN.haloLift * footprint, z);
+      // Lying flat, then leaned opposite ways so the pair reads as a gyroscope.
+      h.mesh.rotation.set(-Math.PI / 2 + COLUMN.haloTilt * h.dir, 0, 0);
+    }
+    this.sync(p);
+    p.column.visible = true;
+    p.star.visible = true;
+    for (const h of p.halos) h.mesh.visible = true;
+  }
+
+  private sync(p: Pillar): void {
+    const t = p.t;
+    // One clock, every beat a threshold on it: the column climbs, the star and
+    // the rings open behind its front, everything fades together at the end.
+    const grown = easeOut(ramp(t, 0, BEATS.rise));
+    const fade = 1 - ramp(t, BEATS.hold, BEATS.life - BEATS.hold);
+    const charge = Math.max(0, 1 - t * 1.4); // hottest at the instant it lands
+    const pulse = 0.5 + 0.5 * Math.sin(t * BEATS.pulseRate * TAU);
+
+    p.uni.uGrown.value = grown;
+    p.uni.uFront.value = 1 - grown;
+    p.uni.uFade.value = fade;
+    p.uni.uCharge.value = charge;
+    p.uni.uPulse.value = pulse;
+
+    const starOpen = easeOut(ramp(t, BEATS.starDelay, BEATS.starTime));
+    p.starUni.uSize.value = COLUMN.starSize * p.footprint * (0.2 + 0.8 * starOpen);
+    p.starUni.uFade.value = fade * starOpen;
+    p.starUni.uCharge.value = charge;
+    p.starUni.uPulse.value = pulse;
+
+    for (const [i, h] of p.halos.entries()) {
+      const open = ramp(t, BEATS.haloDelay + i * BEATS.haloStagger, BEATS.haloTime);
+      h.uni.uOpen.value = open;
+      h.uni.uFade.value = fade;
+      h.uni.uCharge.value = charge;
+      h.uni.uPulse.value = pulse;
+      // Leaned opposite ways and turning opposite ways, on the ring's own
+      // tilted axis — a spin about world-up would keep the lean fixed in
+      // screen space and the pair would stop reading as a gyroscope.
+      h.mesh.rotation.z = t * COLUMN.haloSpin * TAU * h.dir;
+    }
+  }
+
+  update(dt: number): void {
+    for (const p of this.pillars) {
+      if (!p.live) continue;
+      p.t += dt;
+      if (p.t >= BEATS.life) {
+        p.live = false;
+        p.column.visible = false;
+        p.star.visible = false;
+        for (const h of p.halos) h.mesh.visible = false;
+        continue;
+      }
+      this.sync(p);
+    }
+  }
+
+  dispose(): void {
+    for (const p of this.pillars) {
+      for (const m of [p.column, p.star, p.halos[0].mesh, p.halos[1].mesh]) {
+        m.removeFromParent();
+        if (m.material instanceof THREE.Material) m.material.dispose();
+      }
+    }
+    this.pillars.length = 0;
+    this.columnGeo.dispose();
+    this.starGeo.dispose();
+    this.haloGeo.dispose();
+  }
+}

--- a/games/battle-arena/src/render/fx-pool.ts
+++ b/games/battle-arena/src/render/fx-pool.ts
@@ -1,0 +1,381 @@
+// The floor under Grimelda's Cauldron Brew: stone with acid standing in it.
+//
+// Ported from the Elemental Sandbox VFX sandbox (MIT, Copyright (c) 2026
+// mohamedachrefelouafi) — https://github.com/achrefelouafi/LinearAbiltyCastingExtendedThreeJS
+// (the "Caustic Bloom" pool), re-graded from its chartreuse to the witch's bog
+// green and run at two noise octaves instead of three.
+//
+// Three decisions carry it, and they are all about the difference between a
+// POOL and a green light on the floor:
+//
+//   It is alpha blended, not additive. The brew has to eat the floor — darken
+//   the stone, sink the crazing into it, sit WET on top of it. Additive can
+//   only ever add, so an additive pool is a decal that glows.
+//
+//   The surface is glossy. Everything else on this stage is rough, and one
+//   Blinn highlight off a fake normal (a height field differentiated in world
+//   space with screen derivatives) is the cheapest thing that says liquid.
+//
+//   The boundary is corroded, not circular. The outline is pushed around by
+//   a low-frequency noise on the bearing and bitten into by a higher one, so
+//   the pool has bays and headlands. A clean disc reads as a decal whatever is
+//   drawn inside it.
+//
+// On top of that: gas coming OUT of it. `surfaceBoil` gives every cell of a
+// jittered grid its own clock and draws the expanding rim of one bubble
+// breaking the surface — the floor pops continuously without a single
+// particle (the particle bubbles fx.ts adds on top are the ones that leave it).
+//
+// Everything is drawn in METRES from the centre, so the crazing keeps its
+// physical width whatever the zone radius is.
+import * as THREE from "three";
+import { NOISE_GLSL } from "./fx-noise";
+
+const POOL = {
+  plates: 0.62, // plates per metre
+  craze: 0.55, // the finer network laid over them
+  warp: 0.45, // domain warp on the cell centres
+  seam: 0.05, // width of a channel, cell space
+  seamGlow: 1.15,
+  crust: 0.95, // how opaque the sludge crust is
+  relief: 0.8, // fake lighting across the plates
+  sheen: 0.32, // the specular lobe — what says "wet"
+  gloss: 0.42, // 0 = broad and dull, 1 = a tight highlight
+  etch: 0.35, // how much the growing edge is chewed by its own noise
+  etchScale: 1.6,
+  pits: 0.12, // fraction of plates eaten clean through
+  pitScale: 1.6, // pits per metre
+  boilRate: 0.5, // surface bubbles bursting, per second per cell
+  heat: 0.55, // master brightness of the live acid
+  heatFalloff: 1.4, // how fast it goes inert toward the boundary
+  flow: 0.5, // how fast brightness crawls along a channel
+  caustic: 0.25, // interference on the standing acid
+  causticScale: 2.2,
+  boundary: 0.16, // the bleached band on the footprint, metres
+  boundaryGlow: 0.4,
+  core: 0.12, // the brighter pool in the middle
+  coreSize: 0.4, // its radius, × footprint
+  rings: 1.3, // pressure rings running out of the middle
+  ringSpeed: 0.4,
+  /** Metres of quad per metre of footprint: room for the bays and the lip. */
+  quad: 2.6,
+} as const;
+
+/** Grimelda's grade. */
+const BOG = {
+  sludge: 0x0a1104,
+  plate: 0x24310c,
+  acid: 0x86f07a,
+  hot: 0xdcffb0,
+  edge: 0x9fefa8,
+} as const;
+
+const VERT = /* glsl */ `
+varying vec2 vUv;
+varying vec3 vViewDir;
+void main() {
+  vUv = uv;
+  vec4 world = modelMatrix * vec4(position, 1.0);
+  vViewDir = cameraPosition - world.xyz;
+  gl_Position = projectionMatrix * viewMatrix * world;
+}`;
+
+const FRAG = /* glsl */ `
+#define TAU 6.283185307179586
+uniform float uTime;
+uniform float uQuadSize;
+uniform float uRadius;
+uniform float uGrown;   // how far the corrosion has spread, metres
+uniform float uFront;   // brightness of the leading edge, 0 once it lands
+uniform float uSpent;   // 1 fresh → the acid going inert
+uniform float uBoil;    // the surge envelope
+uniform float uSeed;
+uniform float uFade;
+uniform vec3  uColorSludge;
+uniform vec3  uColorCrust;
+uniform vec3  uColorAcid;
+uniform vec3  uColorHot;
+uniform vec3  uColorEdge;
+varying vec2 vUv;
+varying vec3 vViewDir;
+
+${NOISE_GLSL}
+
+const vec3 LIGHT_DIR = normalize(vec3(0.44, 0.83, 0.29)); // the arena sun
+
+float snoise01(vec3 p) { return snoise(p) * 0.5 + 0.5; }
+vec2 hash21(float p) {
+  vec3 p3 = fract(vec3(p) * vec3(0.1031, 0.1030, 0.0973));
+  p3 += dot(p3, p3.yzx + 33.33);
+  return fract((p3.xx + p3.yz) * p3.zy);
+}
+
+/** Nearest-cell voronoi: x = distance to the nearest centre, y = its hash. */
+vec2 voronoi2(vec2 p) {
+  vec2 n = floor(p);
+  vec2 f = fract(p);
+  float md = 8.0;
+  float id = 0.0;
+  for (int j = -1; j <= 1; j++) {
+    for (int i = -1; i <= 1; i++) {
+      vec2 g = vec2(float(i), float(j));
+      vec2 o = hash21(dot(n + g, vec2(7.13, 113.17)));
+      vec2 r = g + o - f;
+      float d = dot(r, r);
+      if (d < md) { md = d; id = nhash11(dot(n + g, vec2(31.7, 57.1))); }
+    }
+  }
+  return vec2(sqrt(md), id);
+}
+
+/**
+ * Two-nearest voronoi: x = distance to the nearest cell EDGE, y = a hash of
+ * the winning cell. The second loop walks the winner's neighbours and
+ * measures the distance to each bisector — the standard crack-network
+ * construction, and the reason these seams fork and meet at proper junctions
+ * instead of ending in mid-air.
+ */
+vec2 voronoiEtch(vec2 p) {
+  vec2 n = floor(p);
+  vec2 f = fract(p);
+  vec2 mg = vec2(0.0);
+  vec2 mr = vec2(0.0);
+  float md = 8.0;
+  float id = 0.0;
+  for (int j = -1; j <= 1; j++) {
+    for (int i = -1; i <= 1; i++) {
+      vec2 g = vec2(float(i), float(j));
+      vec2 o = hash21(dot(n + g, vec2(7.13, 113.17)));
+      vec2 r = g + o - f;
+      float d = dot(r, r);
+      if (d < md) { md = d; mr = r; mg = g; id = nhash11(dot(n + g, vec2(31.7, 57.1))); }
+    }
+  }
+  float edge = 8.0;
+  for (int j = -1; j <= 1; j++) {
+    for (int i = -1; i <= 1; i++) {
+      vec2 g = mg + vec2(float(i), float(j));
+      vec2 o = hash21(dot(n + g, vec2(7.13, 113.17)));
+      vec2 r = g + o - f;
+      vec2 diff = r - mr;
+      float dd = dot(diff, diff);
+      if (dd > 1e-5) edge = min(edge, dot(0.5 * (mr + r), normalize(diff)));
+    }
+  }
+  return vec2(edge, id);
+}
+
+/**
+ * Gas breaking the surface: a jittered grid where every cell keeps its own
+ * clock and size and draws the expanding rim of one bubble. Because the phase
+ * is a fract() of a per-cell rate the pool boils continuously without any two
+ * cells ever being in step. Returns (rim brightness, the dark crater under it).
+ */
+vec2 surfaceBoil(vec2 p, float scale, float rate, float seed) {
+  vec2 g = p * scale;
+  vec2 n = floor(g);
+  vec2 f = fract(g);
+  float rim = 0.0;
+  float crater = 0.0;
+  for (int j = -1; j <= 1; j++) {
+    for (int i = -1; i <= 1; i++) {
+      vec2 o = vec2(float(i), float(j));
+      float cell = dot(n + o, vec2(41.3, 289.1)) + seed;
+      float id = nhash11(cell);
+      vec2 jitter = hash21(cell * 1.37);
+      float phase = fract(uTime * rate * (0.45 + id * 1.1) + id * 9.0);
+      float size = 0.16 + id * 0.30;
+      float r = phase * size;
+      float d = length(o + jitter - f);
+      float w = max(0.018, size * 0.22 * (1.0 - phase * 0.6));
+      float ring = smoothstep(w, 0.0, abs(d - r)) * (1.0 - phase) * (1.0 - phase);
+      rim = max(rim, ring);
+      crater = max(crater, smoothstep(r, r * 0.2, d) * (1.0 - phase) * 0.8);
+    }
+  }
+  return vec2(rim, crater);
+}
+
+void main() {
+  vec2 p = vec2(vUv.x - 0.5, 0.5 - vUv.y) * uQuadSize;
+  float rad = length(p);
+  vec2 dir = rad > 1e-4 ? p / rad : vec2(1.0, 0.0);
+
+  /* ---- the corroded boundary ---- */
+  float bearing = fbm2(vec3(dir * 1.9, uSeed)) * 0.5 + 0.5;
+  float bite = snoise01(vec3(dir * 5.4, uSeed * 3.1 + uTime * 0.05));
+  // Held INSIDE the footprint: the telegraph's hostile rim runs around the
+  // zone's true radius, and a pool that spilled past it would lie about where
+  // the burn stops.
+  float outer = uRadius * (0.80 + bearing * 0.16 + bite * 0.05) + ${POOL.boundary.toFixed(3)} * 0.5;
+  float aa = fwidth(rad) + 0.02;
+  if (rad > outer + aa * 6.0) discard;
+
+  /* ---- how much detail this pixel can actually resolve ---- */
+  // Metres of floor one pixel covers: a centimetre near the camera, tens of
+  // centimetres out where the floor is nearly edge-on. Fading the fine terms
+  // as the footprint outgrows their features is what a mip chain does for a
+  // texture, and it is the only thing that keeps a procedural surface from
+  // sparkling into white speckle at a grazing angle.
+  float footprint = max(fwidth(p.x), fwidth(p.y));
+  float detail = 1.0 - smoothstep(0.02, 0.13, footprint);
+
+  /* ---- the etched stone ---- */
+  vec2 warp = vec2(fbm2(vec3(p * 0.6, uSeed)), fbm2(vec3(p * 0.6, uSeed + 23.1))) * ${POOL.warp.toFixed(3)};
+  vec2 plate = voronoiEtch((p + warp) * ${POOL.plates.toFixed(3)});
+  // A second, much finer network over the first: acid does not shatter stone
+  // into plates the way heat does — it CRAZES it.
+  vec2 craze = voronoiEtch((p - warp * 0.4) * ${(POOL.plates * 4.3).toFixed(3)} + 31.7);
+
+  float seamA = 1.0 - smoothstep(0.0, ${POOL.seam.toFixed(3)}, plate.x);
+  float seamB = 1.0 - smoothstep(0.0, ${(POOL.seam * 1.6).toFixed(3)}, craze.x);
+  float seam = max(seamA, seamB * ${POOL.craze.toFixed(3)} * detail);
+  // The wide bleached lip either side of a channel — where the acid has wicked
+  // into the stone. A channel is a stain first and a light second.
+  float lip = max(1.0 - smoothstep(${POOL.seam.toFixed(3)}, ${(POOL.seam * 3.4).toFixed(3)}, plate.x),
+                  (1.0 - smoothstep(${POOL.seam.toFixed(3)}, ${(POOL.seam * 3.0).toFixed(3)}, craze.x)) * ${(POOL.craze * 0.6).toFixed(3)} * detail);
+
+  /* ---- pits eaten clean through ---- */
+  vec2 pitCell = voronoi2(p * ${POOL.pitScale.toFixed(3)} + uSeed * 5.0);
+  float pitMask = step(${(1 - POOL.pits).toFixed(3)}, pitCell.y);
+  float pit = pitMask * smoothstep(0.42, 0.16, pitCell.x);
+  float pitRim = pitMask * smoothstep(0.10, 0.0, abs(pitCell.x - 0.34));
+
+  /* ---- relief ---- */
+  float grain = fbm2(vec3(p * 3.4, uSeed * 5.0)) * 0.5 + 0.5;
+  // Plates stand proud, channels and pits are sunk, grain on top. The gradient
+  // is taken in WORLD space — screen derivatives of p invert the pixel
+  // footprint — so the lighting is right however the camera is angled.
+  float height = smoothstep(0.0, ${(POOL.seam * 3).toFixed(3)}, plate.x) * 0.7 + grain * 0.3 - pit * 0.55;
+  vec2 dpx = dFdx(p);
+  vec2 dpy = dFdy(p);
+  float det = dpx.x * dpy.y - dpx.y * dpy.x;
+  vec2 grad = vec2(0.0);
+  if (abs(det) > 1e-9) {
+    float hx = dFdx(height);
+    float hy = dFdy(height);
+    grad = vec2(hx * dpy.y - hy * dpx.y, -hx * dpy.x + hy * dpx.x) / det;
+  }
+  vec3 N = normalize(vec3(-grad.x * ${POOL.relief.toFixed(3)}, 1.0, -grad.y * ${POOL.relief.toFixed(3)}));
+  float lambert = clamp(dot(N, LIGHT_DIR), 0.0, 1.0);
+
+  /* ---- it is wet ---- */
+  vec3 V = normalize(vViewDir);
+  vec3 H = normalize(LIGHT_DIR + V);
+  float spec = pow(clamp(dot(N, H), 0.0, 1.0), ${(8 + 82 * POOL.gloss).toFixed(2)}) * ${POOL.sheen.toFixed(3)};
+  // The bleached lip is dry stone, not liquid: a tight lobe left running
+  // across it draws one continuous jagged highlight over the whole pool.
+  spec *= (1.0 - lip * 0.65) * detail;
+  float sheen = pow(1.0 - clamp(dot(N, V), 0.0, 1.0), 3.0) * ${(POOL.sheen * 0.35).toFixed(3)};
+
+  /* ---- how live the acid still is ---- */
+  float surge = 1.0 + uBoil;
+  float radial = clamp(rad / max(uRadius, 0.05), 0.0, 1.0);
+  float heat = ${POOL.heat.toFixed(3)} * uSpent * pow(1.0 - radial, ${POOL.heatFalloff.toFixed(3)});
+  // Not static: brightness crawls along the inside of every channel.
+  float pump = 0.5 + 0.5 * (snoise(vec3(p * 1.7, uTime * ${POOL.flow.toFixed(3)} + uSeed * 3.0)) * 0.5 + 0.5);
+  heat *= pump * surge;
+
+  // Caustics on the standing acid, drawn where the crust is NOT.
+  vec2 cp = p * ${POOL.causticScale.toFixed(3)};
+  float c1 = snoise(vec3(cp, uTime * 0.7 + uSeed));
+  float c2 = snoise(vec3(cp * 1.43 + 11.0, -uTime * 0.53 + uSeed));
+  float caustic = pow(clamp(1.0 - abs(c1 + c2) * 0.9, 0.0, 1.0), 6.0) * ${POOL.caustic.toFixed(3)} * uSpent * detail;
+
+  /* ---- gas coming off it ---- */
+  vec2 boil = surfaceBoil(p, ${(POOL.pitScale * 0.62).toFixed(3)}, ${POOL.boilRate.toFixed(3)}, uSeed * 11.0) * detail;
+
+  /* ---- the corrosion racing out to the boundary ---- */
+  float open = smoothstep(uGrown + 0.25, uGrown - 0.5, rad);
+  // Eaten rather than wiped in: the growing edge is chewed by its own noise,
+  // so the pool spreads the way a stain does.
+  float chew = snoise01(vec3(p * ${POOL.etchScale.toFixed(3)}, uSeed * 7.0)) * ${POOL.etch.toFixed(3)};
+  open = clamp(open - chew * smoothstep(uGrown - 1.2, uGrown + 0.1, rad), 0.0, 1.0);
+  float front = smoothstep(0.6, 0.0, abs(rad - uGrown)) * uFront;
+
+  /* ---- the furniture: boundary band, centre pool, pressure rings ---- */
+  float inner = max(0.01, outer - ${POOL.boundary.toFixed(3)});
+  float band = smoothstep(outer + aa, outer - aa, rad) * smoothstep(inner - aa, inner + aa, rad);
+  float pool = smoothstep(${POOL.coreSize.toFixed(3)} * uRadius, 0.0, rad) * ${POOL.core.toFixed(3)} * uSpent;
+  float ring = pow(0.5 + 0.5 * cos((radial * ${POOL.rings.toFixed(3)} - uTime * ${POOL.ringSpeed.toFixed(3)}) * TAU), 8.0);
+  ring *= smoothstep(uRadius, uRadius * 0.2, rad) * 0.35;
+
+  /* ---- put it together ---- */
+  vec3 crust = mix(uColorSludge, uColorCrust, plate.y * 0.8 + grain * 0.2);
+  crust *= mix(0.42, 1.3, lambert);
+  crust = mix(crust, uColorCrust * 1.4, lip * 0.4);
+  crust = mix(crust, uColorSludge * 0.35, boil.y * 0.7);
+
+  float acidMask = clamp(seam * 0.95 + pit * 0.85 + pitRim + front * 0.8 + boil.x * 0.9, 0.0, 1.0);
+  vec3 acid = mix(uColorAcid, uColorHot, clamp(heat * 0.5 + front + boil.x * 0.5, 0.0, 1.0));
+
+  vec3 color = crust * (1.0 - acidMask);
+  color += acid * acidMask * (heat + front * 1.5) * ${POOL.seamGlow.toFixed(3)};
+  // Bounce onto the stone either side of a channel.
+  color += uColorAcid * lip * heat * 0.3;
+  color += uColorHot * caustic * heat * (1.0 - acidMask) * 0.8;
+  color += uColorEdge * (band * ${POOL.boundaryGlow.toFixed(3)} + pool * surge + ring) * 0.9;
+  // Weighted to where there is actually standing acid to reflect off.
+  color += (spec + sheen) * mix(uColorAcid, uColorHot, 0.55) * (0.12 + acidMask * 0.95);
+
+  float alpha = ${POOL.crust.toFixed(3)} * (1.0 - acidMask * 0.35) + acidMask + band * 0.9 + pool * 0.5;
+  alpha = clamp(alpha, 0.0, 1.0) * open * uFade;
+  if (alpha < 0.004) discard;
+  gl_FragColor = vec4(color, alpha);
+}`;
+
+/** What the zone tells the pool each frame. */
+export type BrewPoolState = {
+  radius: number; // the footprint, metres
+  grown: number; // how far the corrosion has spread, metres
+  front: number; // 0..1 — the leading edge, lit while it spreads
+  spent: number; // 1 fresh → lower as the acid goes inert
+  boil: number; // 0..1 surge envelope
+  fade: number; // 0..1, the pool going at the end
+};
+
+export type BrewPoolMaterial = THREE.ShaderMaterial & {
+  sync(state: BrewPoolState): void;
+  /** The quad-to-footprint ratio, for whoever scales the mesh. */
+  readonly quad: number;
+};
+
+export function createBrewPoolMaterial(clock: { value: number }): BrewPoolMaterial {
+  const uniforms = {
+    uTime: clock,
+    uQuadSize: { value: 10 },
+    uRadius: { value: 3 },
+    uGrown: { value: 0 },
+    uFront: { value: 1 },
+    uSpent: { value: 1 },
+    uBoil: { value: 0 },
+    uSeed: { value: Math.random() * 100 },
+    uFade: { value: 1 },
+    uColorSludge: { value: new THREE.Color(BOG.sludge) },
+    uColorCrust: { value: new THREE.Color(BOG.plate) },
+    uColorAcid: { value: new THREE.Color(BOG.acid) },
+    uColorHot: { value: new THREE.Color(BOG.hot) },
+    uColorEdge: { value: new THREE.Color(BOG.edge) },
+  };
+  const mat = new THREE.ShaderMaterial({
+    uniforms,
+    vertexShader: VERT,
+    fragmentShader: FRAG,
+    transparent: true,
+    depthWrite: false,
+    blending: THREE.NormalBlending,
+    side: THREE.DoubleSide,
+  });
+  return Object.assign(mat, {
+    quad: POOL.quad,
+    sync: (s: BrewPoolState) => {
+      uniforms.uQuadSize.value = s.radius * POOL.quad;
+      uniforms.uRadius.value = s.radius;
+      uniforms.uGrown.value = s.grown;
+      uniforms.uFront.value = s.front;
+      uniforms.uSpent.value = s.spent;
+      uniforms.uBoil.value = s.boil;
+      uniforms.uFade.value = s.fade;
+    },
+  });
+}

--- a/games/battle-arena/src/render/fx-pool.ts
+++ b/games/battle-arena/src/render/fx-pool.ts
@@ -207,7 +207,7 @@ void main() {
   // Held INSIDE the footprint: the telegraph's hostile rim runs around the
   // zone's true radius, and a pool that spilled past it would lie about where
   // the burn stops.
-  float outer = uRadius * (0.80 + bearing * 0.16 + bite * 0.05) + ${POOL.boundary.toFixed(3)} * 0.5;
+  float outer = min(uRadius, uRadius * (0.80 + bearing * 0.16 + bite * 0.05) + ${POOL.boundary.toFixed(3)} * 0.5);
   float aa = fwidth(rad) + 0.02;
   if (rad > outer + aa * 6.0) discard;
 

--- a/games/battle-arena/src/render/fx-ribbon.ts
+++ b/games/battle-arena/src/render/fx-ribbon.ts
@@ -1,0 +1,335 @@
+// Helix ribbons dragged behind a projectile — the wake Grimelda's Hex Bolt
+// leaves as it curdles through the air.
+//
+// Ported from the Elemental Sandbox VFX sandbox (MIT, Copyright (c) 2026
+// mohamedachrefelouafi) — https://github.com/achrefelouafi/LinearAbiltyCastingExtendedThreeJS
+// (the "Cyber Serpent" neon trail), with the sandbox's depth-buffer soft fade
+// dropped (we run no depth prepass) and the palette re-graded from neon cyan
+// to bog green running out to violet.
+//
+// A whole nest of them is ONE draw call: the geometry is the same instanced
+// parameter strip the lightning bolt uses, and each instance winds its own
+// helix about the flight line from nothing but its instance index. The CPU
+// hands over four vectors a frame — where the nose is, and the frame it is
+// flying in — and never touches a vertex. There is no path to go stale, so a
+// projectile that dies mid-flight leaves a wake that dissolves in place.
+//
+// Three things stop this reading as a machined screw thread, which is what a
+// plain helix looks like:
+//   - the RADIUS PROFILE opens just behind the head and closes to a point at
+//     the far end, so a ribbon is a teardrop wrapped around the path;
+//   - each strand carries its own PHASE, PITCH and RADIUS, rolled off its
+//     index, so the strands cross each other instead of nesting;
+//   - a low-frequency WANDER pushes the whole helix off axis — the difference
+//     between a light ribbon and a spring.
+//
+// The strip is billboarded: a fixed normal would make a strand vanish edge-on
+// every half turn, which on a helix is twice a revolution.
+import * as THREE from "three";
+import { NOISE_GLSL } from "./fx-noise";
+
+const POOL = 6;
+const NODES = 40; // samples along the wake
+const STRANDS = 5; // ribbons per wake
+
+const RIBBON = {
+  span: 4.5, // metres of path they reach back over
+  turns: 1.8, // turns each makes over that span
+  spin: 0.35, // turns/second they roll on top of that
+  radius: 0.34, // how far off the axis they ride, metres
+  swell: 0.5, // where along the span they are fattest
+  width: 0.07, // half-width at the head, metres
+  widthTip: 0.5, // that width at the tail, as a multiple
+  wander: 0.12, // metres the helix drifts off axis
+  wanderScale: 2.0,
+  wanderSpeed: 0.8,
+  sharp: 2.8, // falloff across the ribbon
+  core: 20.0, // the hard thread down the middle of it
+  pulse: 1.3, // charge running up it
+  pulseFreq: 2.2,
+  pulseSpeed: 1.3,
+  flicker: 0.3, // it is a curse, not a wire — let it stutter
+  flickerScale: 6.0,
+  flickerSpeed: 2.2,
+  intensity: 1.35,
+  opacity: 0.68,
+  loose: 0.3, // seconds a wake takes to dissolve once its head is gone
+} as const;
+
+/** Bog green out of a white thread, running to violet at the tail. */
+const HEX = { core: 0xf0fff0, body: 0x7fe08a, tail: 0x6a3aa8 } as const;
+
+const VERT = /* glsl */ `
+#define TAU 6.283185307179586
+#define PI  3.141592653589793
+attribute float aStrand;
+uniform float uTime;
+uniform vec3  uHead;   // the nose, in world space
+uniform vec3  uDir;    // unit heading
+uniform vec3  uSide;
+uniform vec3  uUp;
+uniform float uSeed;
+uniform float uSpan;
+uniform float uFade;
+varying float vT;
+varying float vV;
+varying float vStrand;
+
+${NOISE_GLSL}
+
+/* Where strand 'phase' sits at t — 0 at the nose, 1 at the far tail. */
+vec3 pathAt(float t, float phase, float radius, float pitch) {
+  vec3 axis = uHead - uDir * (t * uSpan);
+  // Opens behind the head, closes to a point at the end.
+  float profile = sin(pow(clamp(t, 0.0, 1.0), ${RIBBON.swell.toFixed(3)}) * PI);
+  float r = radius * profile;
+  float angle = phase + t * pitch * TAU - uTime * ${RIBBON.spin.toFixed(3)} * TAU;
+  axis += (uSide * cos(angle) + uUp * sin(angle)) * r;
+  // ... and a slow push off the axis, so the helix breathes.
+  float w = ${RIBBON.wander.toFixed(3)} * profile;
+  axis += uSide * snoise(vec3(t * ${RIBBON.wanderScale.toFixed(3)}, uTime * ${RIBBON.wanderSpeed.toFixed(3)}, phase)) * w;
+  axis += uUp * snoise(vec3(t * ${RIBBON.wanderScale.toFixed(3)} + 19.7, uTime * ${RIBBON.wanderSpeed.toFixed(3)}, phase + 4.3)) * w;
+  return axis;
+}
+
+void main() {
+  float strand = aStrand;
+  float roll = nhash11(strand * 7.13 + uSeed);
+  float roll2 = nhash11(strand * 3.71 + uSeed + 11.3);
+
+  // Evenly spaced around the axis, then jittered — evenly spaced alone makes
+  // the strands read as one rotating cage.
+  float phase = (strand / ${STRANDS.toFixed(1)}) * TAU + roll * 1.7 + uSeed;
+  float radius = ${RIBBON.radius.toFixed(3)} * (0.7 + roll * 0.65);
+  float pitch = ${RIBBON.turns.toFixed(3)} * (0.75 + roll2 * 0.6) * (roll2 > 0.5 ? 1.0 : -1.0);
+
+  float t = clamp(position.x, 0.0, 1.0);
+  const float H = 0.012;
+  vec3 p0 = pathAt(t, phase, radius, pitch);
+  vec3 p1 = pathAt(min(t + H, 1.0), phase, radius, pitch);
+  vec3 tangent = normalize(p1 - p0 + 1e-6);
+
+  vec3 toEye = normalize(cameraPosition - p0);
+  vec3 side = cross(tangent, toEye);
+  if (dot(side, side) < 1e-8) side = uSide;
+  side = normalize(side);
+
+  // Tapered at both ends: a ribbon that stops dead reads as a cut strip.
+  float taper = smoothstep(0.0, 0.06, t) * (1.0 - smoothstep(0.72, 1.0, t));
+  float halfWidth = ${RIBBON.width.toFixed(3)} * mix(1.0, ${RIBBON.widthTip.toFixed(3)}, t) * taper * uFade * (0.7 + roll * 0.6);
+
+  vT = t;
+  vV = position.y;
+  vStrand = strand;
+  gl_Position = projectionMatrix * viewMatrix * vec4(p0 + side * (position.y * halfWidth), 1.0);
+}`;
+
+const FRAG = /* glsl */ `
+uniform float uTime;
+uniform float uSeed;
+uniform float uFade;
+uniform vec3  uColorCore;
+uniform vec3  uColorBody;
+uniform vec3  uColorTail;
+varying float vT;
+varying float vV;
+varying float vStrand;
+
+${NOISE_GLSL}
+
+void main() {
+  /* across the ribbon: a soft body with a hard thread down the middle */
+  float across = clamp(1.0 - abs(vV), 0.0, 1.0);
+  float body = pow(across, ${RIBBON.sharp.toFixed(3)});
+  float core = pow(across, ${RIBBON.core.toFixed(3)});
+
+  /* charge running up the ribbon toward the head */
+  float phase = fract(vT * ${RIBBON.pulseFreq.toFixed(3)} + uTime * ${RIBBON.pulseSpeed.toFixed(3)} + vStrand * 0.37);
+  float pulse = pow(1.0 - abs(phase * 2.0 - 1.0), 6.0) * ${RIBBON.pulse.toFixed(3)};
+
+  /* let it stutter */
+  float flicker = snoise(vec3(vT * ${RIBBON.flickerScale.toFixed(3)}, uTime * ${RIBBON.flickerSpeed.toFixed(3)}, vStrand * 5.1 + uSeed)) * 0.5 + 0.5;
+  flicker = mix(1.0, flicker, ${RIBBON.flicker.toFixed(3)});
+
+  float energy = (body * (1.0 + pulse) + core * 1.6) * flicker;
+  // The far end goes to nothing: the ribbon dissolves into the wake instead of
+  // ending on a line.
+  energy *= 1.0 - smoothstep(0.55, 1.0, vT);
+
+  vec3 color = mix(uColorBody, uColorTail, smoothstep(0.15, 0.8, vT));
+  color = mix(color, uColorCore, clamp(core + pulse * 0.7, 0.0, 1.0));
+  color *= energy * ${RIBBON.intensity.toFixed(3)};
+
+  float alpha = clamp(energy, 0.0, 1.0) * ${RIBBON.opacity.toFixed(3)} * uFade;
+  if (alpha < 0.004) discard;
+  // Rolled off hard: a ribbon that clips is a white noodle.
+  color /= 1.0 + color * 0.18;
+  gl_FragColor = vec4(color, alpha);
+}`;
+
+/** The bolt's strip: (t, ±1) per vertex, one instance per strand. */
+function createStripGeometry(): THREE.InstancedBufferGeometry {
+  const positions = new Float32Array(NODES * 2 * 3);
+  for (let i = 0; i < NODES; i++) {
+    const t = i / (NODES - 1);
+    const o = i * 6;
+    positions[o] = t;
+    positions[o + 1] = -1;
+    positions[o + 3] = t;
+    positions[o + 4] = 1;
+  }
+  const indices = new Uint16Array((NODES - 1) * 6);
+  for (let i = 0; i < NODES - 1; i++) {
+    const a = i * 2;
+    const o = i * 6;
+    indices[o] = a;
+    indices[o + 1] = a + 1;
+    indices[o + 2] = a + 2;
+    indices[o + 3] = a + 1;
+    indices[o + 4] = a + 3;
+    indices[o + 5] = a + 2;
+  }
+  const strand = new Float32Array(STRANDS);
+  for (let i = 0; i < STRANDS; i++) strand[i] = i;
+  const geo = new THREE.InstancedBufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  geo.setAttribute("aStrand", new THREE.InstancedBufferAttribute(strand, 1));
+  geo.setIndex(new THREE.BufferAttribute(indices, 1));
+  geo.instanceCount = STRANDS;
+  geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e4);
+  return geo;
+}
+
+type RibbonUniforms = {
+  uTime: { value: number };
+  uHead: { value: THREE.Vector3 };
+  uDir: { value: THREE.Vector3 };
+  uSide: { value: THREE.Vector3 };
+  uUp: { value: THREE.Vector3 };
+  uSeed: { value: number };
+  uSpan: { value: number };
+  uFade: { value: number };
+  uColorCore: { value: THREE.Color };
+  uColorBody: { value: THREE.Color };
+  uColorTail: { value: THREE.Color };
+};
+
+type Ribbon = {
+  mesh: THREE.Mesh;
+  uni: RibbonUniforms;
+  id: string; // the projectile it follows; "" when free
+  fed: boolean; // followed this frame
+  loose: number; // seconds since its head last reported in
+};
+
+export type RibbonPalette = { core: number; body: number; tail: number };
+
+/** Pooled projectile wakes, keyed by the projectile they follow. */
+export class RibbonPool {
+  private ribbons: Ribbon[] = [];
+  private geo = createStripGeometry();
+
+  constructor(
+    private scene: THREE.Scene,
+    clock: { value: number },
+  ) {
+    for (let i = 0; i < POOL; i++) {
+      const uni: RibbonUniforms = {
+        uTime: clock,
+        uHead: { value: new THREE.Vector3() },
+        uDir: { value: new THREE.Vector3(0, 0, 1) },
+        uSide: { value: new THREE.Vector3(1, 0, 0) },
+        uUp: { value: new THREE.Vector3(0, 1, 0) },
+        uSeed: { value: 0 },
+        uSpan: { value: 0 },
+        uFade: { value: 1 },
+        uColorCore: { value: new THREE.Color(HEX.core) },
+        uColorBody: { value: new THREE.Color(HEX.body) },
+        uColorTail: { value: new THREE.Color(HEX.tail) },
+      };
+      const mesh = new THREE.Mesh(
+        this.geo,
+        new THREE.ShaderMaterial({
+          uniforms: uni,
+          vertexShader: VERT,
+          fragmentShader: FRAG,
+          transparent: true,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+          side: THREE.DoubleSide,
+        }),
+      );
+      mesh.frustumCulled = false;
+      mesh.visible = false;
+      mesh.renderOrder = 6;
+      this.scene.add(mesh);
+      this.ribbons.push({ mesh, uni, id: "", fed: false, loose: 0 });
+    }
+  }
+
+  /**
+   * Report a projectile's nose this frame. (x, h, z) is its world position,
+   * (dx, dz) its unit heading on the floor, `traveled` how far it has flown —
+   * the wake only reaches back as far as the bolt has actually been, so it
+   * does not pop out of the caster's back fully formed.
+   */
+  follow(
+    id: string,
+    x: number,
+    h: number,
+    z: number,
+    dx: number,
+    dz: number,
+    traveled: number,
+    palette: RibbonPalette = HEX,
+  ): void {
+    let r = this.ribbons.find((e) => e.id === id);
+    if (!r) {
+      r = this.ribbons.find((e) => e.id === "");
+      if (!r) return; // saturated — this bolt flies without a wake
+      r.id = id;
+      r.loose = 0;
+      r.uni.uSeed.value = Math.random() * 100;
+      r.uni.uColorCore.value.setHex(palette.core);
+      r.uni.uColorBody.value.setHex(palette.body);
+      r.uni.uColorTail.value.setHex(palette.tail);
+      r.mesh.visible = true;
+    }
+    r.fed = true;
+    r.uni.uHead.value.set(x, h, z);
+    r.uni.uDir.value.set(dx, 0, dz);
+    r.uni.uSide.value.set(-dz, 0, dx);
+    r.uni.uSpan.value = Math.min(RIBBON.span, traveled + 0.4);
+  }
+
+  update(dt: number): void {
+    for (const r of this.ribbons) {
+      if (r.id === "") continue;
+      if (r.fed) {
+        r.fed = false;
+        r.loose = 0;
+        r.uni.uFade.value = 1;
+        continue;
+      }
+      // The head is gone (the bolt burst or fizzled): the wake dissolves where
+      // it was, tail first.
+      r.loose += dt;
+      const k = r.loose / RIBBON.loose;
+      if (k >= 1) {
+        r.id = "";
+        r.mesh.visible = false;
+        continue;
+      }
+      r.uni.uFade.value = 1 - k;
+    }
+  }
+
+  dispose(): void {
+    for (const r of this.ribbons) {
+      r.mesh.removeFromParent();
+      if (r.mesh.material instanceof THREE.Material) r.mesh.material.dispose();
+    }
+    this.ribbons.length = 0;
+    this.geo.dispose();
+  }
+}

--- a/games/battle-arena/src/render/fx-ribbon.ts
+++ b/games/battle-arena/src/render/fx-ribbon.ts
@@ -289,6 +289,10 @@ export class RibbonPool {
       if (!r) return; // saturated — this bolt flies without a wake
       r.id = id;
       r.loose = 0;
+      // A slot freed by a wake that had faded out still carries that fade —
+      // reset it here, not in update(), or the new wake's first frame draws
+      // at whatever the old one died at.
+      r.uni.uFade.value = 1;
       r.uni.uSeed.value = Math.random() * 100;
       r.uni.uColorCore.value.setHex(palette.core);
       r.uni.uColorBody.value.setHex(palette.body);

--- a/games/battle-arena/src/render/fx-void.ts
+++ b/games/battle-arena/src/render/fx-void.ts
@@ -1,0 +1,306 @@
+// The singularity — the black hole Grimelda's Grand Hex tears open over the
+// sealing circle: a shadow, the photon ring piled up on its edge, and the
+// lensed light wound around it.
+//
+// Ported from the Elemental Sandbox VFX sandbox (MIT, Copyright (c) 2026
+// mohamedachrefelouafi) — https://github.com/achrefelouafi/LinearAbiltyCastingExtendedThreeJS
+// (the "Astral Void Blast" horizon). The sandbox also bends the finished frame
+// around the hole through a screen-space distortion pass; we have no such
+// pass, so the lens is dropped and the halo carries the read on its own. The
+// palette is re-graded from the sandbox's gold-on-violet to Grimelda's bog
+// green ring on a violet halo, so it stays hers and not a generic void.
+//
+// Why a camera-facing quad rather than a sphere: a Schwarzschild shadow is
+// CIRCULAR from every direction — it is not the silhouette of a sphere but the
+// set of impact parameters below which a photon cannot escape, rotationally
+// symmetric about the line of sight whatever the observer does. So a billboard
+// is the correct primitive: exactly round at every camera angle, antialiased
+// against one analytic radius instead of a tessellated limb.
+//
+// The disc is PREMULTIPLIED. Inside the shadow the colour is zero and the
+// alpha is one, so the frame behind it is replaced by nothing. Straight alpha
+// with a near-black colour leaves a dark grey disc, and a grey black hole is
+// not a black hole.
+import * as THREE from "three";
+import { NOISE_GLSL } from "./fx-noise";
+
+const POOL = 2;
+
+/** Every dimension below is × the zone's footprint radius. */
+const HOLE = {
+  horizon: 0.22, // the settled shadow
+  height: 0.52, // how far off the floor it hangs — a body has to be LIFTED in
+  reach: 4.5, // how far the halo is drawn, × the horizon
+  ringWidth: 0.05, // thickness of the photon ring, in horizon radii
+  // The sandbox runs the ring at 9 under a gentle bloom. Under ours that
+  // blooms into a white blob that buries the shadow — the one thing the
+  // effect is for — so it sits just over the bloom threshold instead.
+  ringGlow: 1.4,
+  beam: 0.75, // how hard one side of the ring is beamed, 0 = evenly lit
+  beamSpin: 0.22, // revolutions/second the beamed side travels
+  halo: 0.9,
+  haloFalloff: 2.4, // how fast the halo dies outward
+  wind: 2.4, // differential winding — inner strands lap outer ones
+  spin: 0.3, // revolutions/second the whole halo turns
+  filament: 0.7, // how far the halo is torn into strands
+  filamentScale: 2.2,
+} as const;
+
+/** The sequence, in seconds since it opened. */
+const BEATS = {
+  swell: 0.3, // inflating to its overshoot
+  bloom: 1.35, // × the settled horizon at the top of that
+  settle: 0.55, // back at its settled size
+  pinch: 0.22, // the collapse, at the end
+} as const;
+
+const TAU = Math.PI * 2;
+
+const VERT = /* glsl */ `
+uniform float uSize;     // half-width of the quad, metres
+uniform float uHorizon;  // radius of the shadow, metres
+varying vec2 vLocal;     // -1..1 across the quad
+void main() {
+  // PlaneGeometry(1, 1) spans -0.5..0.5, so this is the unit square doubled.
+  vLocal = position.xy * 2.0;
+  // Camera facing: the quad's own basis is thrown away and its corners are
+  // laid out in view space around the object's origin.
+  vec4 mv = modelViewMatrix * vec4(0.0, 0.0, 0.0, 1.0);
+  mv.xy += position.xy * (uSize * 2.0);
+  // Pulled forward to the NEAR surface of the sphere it stands for: a
+  // silhouette is at the limb, not the middle, and it is what makes a body
+  // being drawn into the hole go behind it instead of z-fighting through the
+  // one surface in the frame that has to stay solid black.
+  mv.z += uHorizon;
+  gl_Position = projectionMatrix * mv;
+}`;
+
+const FRAG = /* glsl */ `
+#define TAU 6.283185307179586
+uniform float uTime;
+uniform float uSize;
+uniform float uHorizon;
+uniform float uBeamPhase;
+uniform float uChurn;     // the flare envelope, 0..1
+uniform float uSeed;
+uniform float uFade;
+uniform vec3  uColorPhoton;
+uniform vec3  uColorHalo;
+uniform vec3  uColorCool;
+varying vec2 vLocal;
+
+${NOISE_GLSL}
+
+mat2 rot2(float a) { float c = cos(a); float s = sin(a); return mat2(c, -s, s, c); }
+
+void main() {
+  float len = length(vLocal);
+  if (len > 1.0) discard;
+
+  // Everything below is measured in horizon radii, so every threshold is a
+  // shape rather than a distance and the whole disc rescales for free.
+  float scale = uSize / max(uHorizon, 1e-3);
+  float r = len * scale;
+  float ang = atan(vLocal.y, vLocal.x);
+
+  // One pixel, in those same units. Every band is floored at it, or the ring
+  // aliases into a dashed circle the moment the camera pulls back.
+  float px = max(fwidth(r), 1e-4);
+
+  /* ---- the shadow ---- */
+  float shadow = 1.0 - smoothstep(1.0 - px, 1.0 + px, r);
+
+  /* ---- which side is coming toward us ---- */
+  // Relativistic beaming, near enough: the approaching limb is brighter, the
+  // receding one dimmer — the cheapest detail that says this is TURNING.
+  float toward = cos(ang - uBeamPhase);
+  float beam = 1.0 + ${HOLE.beam.toFixed(3)} * toward;
+
+  /* ---- the photon ring ---- */
+  // Sat right on the shadow's edge and floored at a pixel. Energy is kept as
+  // the band widens, so pulling the camera back dims the ring rather than
+  // turning it into a fat bright donut.
+  float width = max(${HOLE.ringWidth.toFixed(3)}, px * 1.1);
+  float d = (r - 1.0 - width * 0.65) / width;
+  float ring = exp(-d * d * 2.2) * (${HOLE.ringWidth.toFixed(3)} / width);
+  // A second, much fainter ring outside it: light that went round twice. It is
+  // nearly subliminal, and it stops the first ring reading as a drawn outline.
+  float d2 = (r - 1.0 - width * 3.4) / (width * 1.6);
+  ring += exp(-d2 * d2 * 2.0) * 0.16 * (${HOLE.ringWidth.toFixed(3)} / width);
+
+  /* ---- the lensed halo ---- */
+  // Wound at a differential rate: the strands nearest the hole overtake the
+  // ones outside them, which is what an orbit does and a spinning texture
+  // does not.
+  float turn = uTime * ${HOLE.spin.toFixed(3)} * TAU + ${HOLE.wind.toFixed(3)} / (0.25 + r * 0.85);
+  vec2 wound = rot2(turn) * vLocal;
+  float strands = ridged(vec3(wound * ${HOLE.filamentScale.toFixed(3)}, uTime * 0.25 + uSeed));
+  strands = mix(1.0, smoothstep(0.25, 0.95, strands), ${HOLE.filament.toFixed(3)});
+
+  // Falls off outward from the ring, and is cut dead inside the shadow —
+  // there is nothing in there to be lit.
+  float halo = exp(-(r - 1.0) * ${HOLE.haloFalloff.toFixed(3)}) * smoothstep(1.0 - px, 1.0 + px * 2.0, r);
+  halo *= strands;
+
+  /* ---- put it together ---- */
+  float flare = 1.0 + uChurn * 0.55;
+  vec3 color = uColorPhoton * ring * ${HOLE.ringGlow.toFixed(2)} * beam * flare;
+  // The halo cools with distance: hot at the ring, deep violet at the reach.
+  vec3 haloTint = mix(uColorHalo, uColorCool, smoothstep(1.0, scale * 0.75, r));
+  color += haloTint * halo * ${HOLE.halo.toFixed(3)} * beam * flare;
+  color *= uFade;
+
+  // The disc is opaque; outside it the glow carries its own coverage, so it
+  // adds to the frame instead of veiling it.
+  float glow = ring * ${HOLE.ringGlow.toFixed(2)} + halo * ${HOLE.halo.toFixed(3)};
+  float alpha = clamp(shadow + glow * 0.3 * uFade, 0.0, 1.0);
+  if (alpha < 0.002) discard;
+
+  // Premultiplied: inside the shadow the colour is zero and the alpha is one.
+  gl_FragColor = vec4(color * (1.0 - shadow), alpha);
+}`;
+
+type VoidUniforms = {
+  uTime: { value: number };
+  uSize: { value: number };
+  uHorizon: { value: number };
+  uBeamPhase: { value: number };
+  uChurn: { value: number };
+  uSeed: { value: number };
+  uFade: { value: number };
+  uColorPhoton: { value: THREE.Color };
+  uColorHalo: { value: THREE.Color };
+  uColorCool: { value: THREE.Color };
+};
+
+type Hole = {
+  mesh: THREE.Mesh;
+  uni: VoidUniforms;
+  t: number;
+  life: number;
+  live: boolean;
+  horizon: number; // the settled shadow radius, metres
+};
+
+export type VoidOpts = {
+  /** Seconds it stands, collapse included. */
+  life?: number;
+  colors?: { photon: number; halo: number; cool: number };
+};
+
+/** Grimelda's grade: a bog-green photon ring on a violet halo. */
+const HEX = { photon: 0xb4ffa8, halo: 0xb98ae0, cool: 0x2a1450 } as const;
+
+const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
+
+/** Pooled singularities. One billboard, one draw call each. */
+export class VoidPool {
+  private holes: Hole[] = [];
+  private geo = new THREE.PlaneGeometry(1, 1);
+
+  constructor(
+    private scene: THREE.Scene,
+    clock: { value: number },
+  ) {
+    for (let i = 0; i < POOL; i++) {
+      const uni: VoidUniforms = {
+        uTime: clock,
+        uSize: { value: 1 },
+        uHorizon: { value: 0.3 },
+        uBeamPhase: { value: 0 },
+        uChurn: { value: 0 },
+        uSeed: { value: 0 },
+        uFade: { value: 1 },
+        uColorPhoton: { value: new THREE.Color(HEX.photon) },
+        uColorHalo: { value: new THREE.Color(HEX.halo) },
+        uColorCool: { value: new THREE.Color(HEX.cool) },
+      };
+      const mesh = new THREE.Mesh(
+        this.geo,
+        new THREE.ShaderMaterial({
+          uniforms: uni,
+          vertexShader: VERT,
+          fragmentShader: FRAG,
+          transparent: true,
+          depthWrite: false,
+          blending: THREE.NormalBlending,
+          premultipliedAlpha: true,
+          side: THREE.DoubleSide,
+        }),
+      );
+      mesh.frustumCulled = false;
+      mesh.visible = false;
+      mesh.renderOrder = 5;
+      this.scene.add(mesh);
+      this.holes.push({ mesh, uni, t: 0, life: 1, live: false, horizon: 0.3 });
+    }
+  }
+
+  /** Tear one open over (x, groundY, z), sized to a zone of radius `footprint`. */
+  open(x: number, groundY: number, z: number, footprint: number, opts: VoidOpts = {}): void {
+    const h = this.holes.find((e) => !e.live);
+    if (!h) return; // saturated — drop
+    const colors = opts.colors ?? HEX;
+    h.live = true;
+    h.t = 0;
+    h.life = opts.life ?? 1.6;
+    h.horizon = HOLE.horizon * footprint;
+    h.mesh.position.set(x, groundY + HOLE.height * footprint, z);
+    h.uni.uSeed.value = Math.random() * 100;
+    h.uni.uColorPhoton.value.setHex(colors.photon);
+    h.uni.uColorHalo.value.setHex(colors.halo);
+    h.uni.uColorCool.value.setHex(colors.cool);
+    this.sync(h);
+    h.mesh.visible = true;
+  }
+
+  private sync(h: Hole): void {
+    const t = h.t;
+    // Inflates past its size and settles back, then at the very end pinches
+    // to nothing — the collapse is faster than the opening, on purpose.
+    let size: number;
+    if (t < BEATS.swell) {
+      const k = t / BEATS.swell;
+      size = BEATS.bloom * (1 - (1 - k) * (1 - k));
+    } else if (t < BEATS.settle) {
+      const k = (t - BEATS.swell) / (BEATS.settle - BEATS.swell);
+      size = BEATS.bloom + (1 - BEATS.bloom) * k;
+    } else {
+      size = 1;
+    }
+    const pinchStart = h.life - BEATS.pinch;
+    const pinch = clamp01((t - pinchStart) / BEATS.pinch);
+    size *= 1 - pinch * pinch;
+    // The halo flares as it opens and again as it goes.
+    const churn = Math.max(1 - t / BEATS.settle, pinch);
+
+    const horizon = Math.max(0.01, h.horizon * size);
+    h.uni.uHorizon.value = horizon;
+    h.uni.uSize.value = horizon * HOLE.reach;
+    h.uni.uBeamPhase.value = t * HOLE.beamSpin * TAU;
+    h.uni.uChurn.value = churn;
+    h.uni.uFade.value = 1 - pinch * 0.5;
+  }
+
+  update(dt: number): void {
+    for (const h of this.holes) {
+      if (!h.live) continue;
+      h.t += dt;
+      if (h.t >= h.life) {
+        h.live = false;
+        h.mesh.visible = false;
+        continue;
+      }
+      this.sync(h);
+    }
+  }
+
+  dispose(): void {
+    for (const h of this.holes) {
+      h.mesh.removeFromParent();
+      if (h.mesh.material instanceof THREE.Material) h.mesh.material.dispose();
+    }
+    this.holes.length = 0;
+    this.geo.dispose();
+  }
+}

--- a/games/battle-arena/src/render/fx.ts
+++ b/games/battle-arena/src/render/fx.ts
@@ -185,6 +185,7 @@ export class Fx {
   private cometGeo = createRockGeometry({ seed: 4, detail: 2, craters: 6, cuts: 8 });
   private rockMat = createBurningRockMaterial(fxClock);
   private pendingWarm: { renderer: THREE.WebGLRenderer; camera: THREE.Camera } | null = null;
+  private warmParked: { mesh: THREE.Mesh; ownMat: boolean }[] = []; // warmRig stand-ins
   private texturesReady = false;
   private boltFrom = new THREE.Vector3();
   private boltTo = new THREE.Vector3();
@@ -389,16 +390,19 @@ export class Fx {
    * Invisible costs nothing to render and still compiles.
    */
   private warmRig(scene: THREE.Scene): void {
-    const park = (mesh: THREE.Mesh) => {
+    // `ownMat`: the stand-in's material exists only for the warm pass and is
+    // disposed with it. The rock's is shared with the meteor and lives with it.
+    const park = (mesh: THREE.Mesh, ownMat: boolean) => {
       mesh.visible = false;
       mesh.frustumCulled = false;
       mesh.position.set(0, -1000, 0);
       scene.add(mesh);
+      this.warmParked.push({ mesh, ownMat });
     };
-    park(new THREE.Mesh(this.cometGeo, this.rockMat));
+    park(new THREE.Mesh(this.cometGeo, this.rockMat), false);
     // The brew pool is built per zone (its material owns the zone's seed), so
     // the same stand-in trick covers its program.
-    park(new THREE.Mesh(this.ringPlane, createBrewPoolMaterial(fxClock)));
+    park(new THREE.Mesh(this.ringPlane, createBrewPoolMaterial(fxClock)), true);
     // The tex* helpers build a fresh MeshBasicMaterial per call, so their
     // programs are never in the scene at warm time either. One stand-in per
     // blend mode covers every one of them — the program key is the same.
@@ -414,6 +418,7 @@ export class Fx {
             side: THREE.DoubleSide,
           }),
         ),
+        true,
       );
     }
   }
@@ -2733,6 +2738,11 @@ export class Fx {
     }
     this.zonePieces.clear();
     this.brewPools.clear();
+    for (const { mesh, ownMat } of this.warmParked) {
+      this.scene.remove(mesh);
+      if (ownMat && mesh.material instanceof THREE.Material) mesh.material.dispose();
+    }
+    this.warmParked.length = 0;
     for (const g of this.coneGeoCache.values()) g.dispose();
     for (const g of this.rimGeoCache.values()) g.dispose();
     this.ringPlane.dispose();

--- a/games/battle-arena/src/render/fx.ts
+++ b/games/battle-arena/src/render/fx.ts
@@ -26,6 +26,10 @@ import { createBurningRockMaterial } from "./fx-rock";
 import { createBeamMaterial, type BeamMaterial } from "./fx-beam";
 import { SpikePool } from "./fx-spikes";
 import { BoltPool } from "./fx-bolt";
+import { PillarPool } from "./fx-pillar";
+import { VoidPool } from "./fx-void";
+import { RibbonPool } from "./fx-ribbon";
+import { createBrewPoolMaterial, type BrewPoolMaterial } from "./fx-pool";
 import { HDR_BRIGHT, ParticlePools, type SpawnOptions } from "./fx-particles";
 import { Telegraphs, groundFxColor } from "./telegraph";
 import type { View } from "./view";
@@ -116,7 +120,14 @@ type Slash = {
 };
 type Crack = { mesh: THREE.Mesh; mat: CrackMaterial; life: number; maxLife: number };
 type Delayed = { at: number; run: () => void };
-type ZoneAnim = { next: number; next2: number; phase: number; seenAt: number; born: boolean };
+type ZoneAnim = {
+  next: number;
+  next2: number;
+  phase: number;
+  seenAt: number;
+  bornAt: number; // sim ms the zone first appeared — pools grow off this
+  born: boolean;
+};
 
 const scratch: SpawnOptions = { x: 0, y: 0, z: 0, size: 0.5, life: 0.3 };
 
@@ -148,6 +159,9 @@ export class Fx {
   readonly chunks: ChunkPool;
   readonly spikes: SpikePool;
   readonly bolts: BoltPool;
+  readonly pillars: PillarPool;
+  readonly voids: VoidPool;
+  readonly ribbons: RibbonPool; // projectile wakes — world-view feeds them per frame
   private rings: Ring[] = [];
   private beams: Beam[] = [];
   private cones: ConeDecal[] = [];
@@ -166,6 +180,7 @@ export class Fx {
   private rimGeoCache = new Map<number, THREE.RingGeometry>();
   private ringPlane = new THREE.PlaneGeometry(2, 2);
   private zonePieces = new Map<string, ZonePiece>();
+  private brewPools = new Map<string, BrewPoolMaterial>(); // the brew zone pieces' materials, by zone id
   private vortexGeo = new THREE.CylinderGeometry(1, 0.72, 1, 20, 1, true);
   private cometGeo = createRockGeometry({ seed: 4, detail: 2, craters: 6, cuts: 8 });
   private rockMat = createBurningRockMaterial(fxClock);
@@ -220,6 +235,9 @@ export class Fx {
     this.chunks = new ChunkPool(scene);
     this.spikes = new SpikePool(scene);
     this.bolts = new BoltPool(scene, fxClock);
+    this.pillars = new PillarPool(scene, fxClock);
+    this.voids = new VoidPool(scene, fxClock);
+    this.ribbons = new RibbonPool(scene, fxClock);
 
     for (let i = 0; i < RING_POOL; i++) {
       // shader annulus: noise-broken rim + hot edge (see fx-shaders makeRingMaterial)
@@ -378,6 +396,9 @@ export class Fx {
       scene.add(mesh);
     };
     park(new THREE.Mesh(this.cometGeo, this.rockMat));
+    // The brew pool is built per zone (its material owns the zone's seed), so
+    // the same stand-in trick covers its program.
+    park(new THREE.Mesh(this.ringPlane, createBrewPoolMaterial(fxClock)));
     // The tex* helpers build a fresh MeshBasicMaterial per call, so their
     // programs are never in the scene at warm time either. One stand-in per
     // blend mode covers every one of them — the program key is the same.
@@ -449,6 +470,9 @@ export class Fx {
     this.chunks.update(vdt);
     this.spikes.update(vdt);
     this.bolts.update(vdt);
+    this.pillars.update(vdt);
+    this.voids.update(vdt);
+    this.ribbons.update(vdt);
     this.stepRings(vdt);
     this.stepBeams(vdt);
     this.stepCones(vdt);
@@ -465,6 +489,7 @@ export class Fx {
         this.scene.remove(p.obj);
         p.ownMat?.dispose();
         this.zonePieces.delete(id);
+        this.brewPools.delete(id);
       }
     }
 
@@ -644,8 +669,11 @@ export class Fx {
             break;
           }
           case "hexring": {
-            // grand hex seals: violet implosion, spores, and a comedy of tiny
-            // mushrooms sprouting where the victims stood
+            // grand hex seals: a VOID tears open over the circle and hangs
+            // there swallowing light while the spell takes — then a violet
+            // implosion, spores, and a comedy of tiny mushrooms sprouting
+            // where the victims stood
+            this.voids.open(e.x, terrainHeight(e.x, e.y), e.y, e.radius, { life: 1.7 });
             this.implode(e.x, e.y, 0xb98ae0, e.radius, 10, 0.24);
             this.shockwave(e.x, e.y, 0x7fe08a, e.radius, 0.5, 0.7);
             this.spikes.scatter(e.x, e.y, e.radius * 0.75, 6, 0xb98ae0, {
@@ -668,6 +696,11 @@ export class Fx {
               });
               this.bubbles(hx, hy, 8, 0x9fefa8, hr * 0.7);
             });
+            // light pulled in over the hold — a hole that only sits there is
+            // a black disc; one that is fed reads as pulling
+            for (const t of [0.45, 0.8, 1.15]) {
+              this.delay(t, () => this.implode(hx, hy, 0x9fefa8, hr * 0.9, 8, 0.3));
+            }
             break;
           }
           case "vines": // bog grasp: a jaw of vines SNAPS shut around the point
@@ -696,8 +729,10 @@ export class Fx {
               tiltOut: -0.5,
             });
             break;
-          case "smite": // consecrating smite: heaven ANSWERS — bolt + cracked earth
-            this.strikeDown(e.x, e.y, 12, 0xffe6a0, 0xff9a2e, { life: 0.42, scale: 1.5 });
+          case "smite": // consecrating smite: heaven ANSWERS — the column stands up
+            // on the mark, a star welded to its head, two rings turning about
+            // it; cracked earth and gold sparks where it meets the stone
+            this.pillars.strike(e.x, terrainHeight(e.x, e.y), e.y, e.radius);
             this.texDecal("ground-crack", e.x, e.y, { size: 4.4, life: 1.8, additive: false });
             this.texSprite("electric-splat", e.x, 0.8, e.y, {
               size: 3.2,
@@ -1379,7 +1414,7 @@ export class Fx {
   zoneAmbient(g: GroundEffect, now: number): void {
     let st = this.zoneAnim.get(g.id);
     if (!st) {
-      st = { next: 0, next2: 0, phase: Math.random() * 6, seenAt: now, born: true };
+      st = { next: 0, next2: 0, phase: Math.random() * 6, seenAt: now, bornAt: now, born: true };
       this.zoneAnim.set(g.id, st);
     }
     st.seenAt = now;
@@ -1528,6 +1563,38 @@ export class Fx {
         break;
       }
       case "brew": {
+        // the pool itself: acid standing in etched stone, spreading out from
+        // the spill over the first half second, going inert over the zone's
+        // life, and draining away over its last half second
+        const pool = this.zonePiece(g.id, () => {
+          const mat = createBrewPoolMaterial(fxClock);
+          this.brewPools.set(g.id, mat);
+          const mesh = new THREE.Mesh(this.ringPlane, mat);
+          mesh.rotation.x = -Math.PI / 2;
+          mesh.renderOrder = 4.5; // over the telegraph disc, under the bubbles
+          mesh.position.set(g.x, terrainHeight(g.x, g.y) + 0.06, g.y);
+          mesh.scale.setScalar((r * mat.quad) / 2); // ringPlane is 2×2
+          return { obj: mesh, ownMat: mat };
+        });
+        pool.seenAt = now;
+        const brewPool = this.brewPools.get(g.id);
+        if (brewPool) {
+          const age = (now - st.bornAt) / 1000;
+          const total = Math.max(0.5, (g.until - st.bornAt) / 1000);
+          const spread = Math.min(1, age / 0.42);
+          const left = (g.until - now) / 1000;
+          // the boil envelope: mostly still, with surges (a sine spiked by a
+          // power) — the bubbles below vent on the same beat
+          const surge = Math.pow(0.5 + 0.5 * Math.sin(age * Math.PI + st.phase), 2.6);
+          brewPool.sync({
+            radius: r,
+            grown: r * 1.25 * (1 - (1 - spread) * (1 - spread)),
+            front: 1 - spread,
+            spent: 1 - 0.6 * Math.min(1, age / total),
+            boil: surge * 0.9,
+            fade: Math.min(1, Math.max(0, left / 0.5)),
+          });
+        }
         if (st.born) {
           // the cauldron tips over: a green splash + droplets before it settles
           st.born = false;
@@ -2657,11 +2724,15 @@ export class Fx {
     }
     this.spikes.dispose();
     this.bolts.dispose();
+    this.pillars.dispose();
+    this.voids.dispose();
+    this.ribbons.dispose();
     for (const [, p] of this.zonePieces) {
       this.scene.remove(p.obj);
       p.ownMat?.dispose();
     }
     this.zonePieces.clear();
+    this.brewPools.clear();
     for (const g of this.coneGeoCache.values()) g.dispose();
     for (const g of this.rimGeoCache.values()) g.dispose();
     this.ringPlane.dispose();

--- a/games/battle-arena/src/render/world-view.ts
+++ b/games/battle-arena/src/render/world-view.ts
@@ -953,6 +953,20 @@ export class WorldView {
       }
       // additive trail behind the projectile
       this.fx?.trail(mesh.position.x, mesh.position.z, projectileColor(p.kind));
+      // the hex bolt drags a nest of helix ribbons — one draw call, built in
+      // the vertex shader off the nose and heading we hand it here
+      if (p.kind === "hexbolt") {
+        const spd = Math.hypot(p.vx, p.vy) || 1;
+        this.fx?.ribbons.follow(
+          p.id,
+          mesh.position.x,
+          mesh.position.y,
+          mesh.position.z,
+          p.vx / spd,
+          p.vy / spd,
+          p.traveled,
+        );
+      }
       // fireballs drag a smoke tracer — matter under the energy
       if (p.kind === "fireball") {
         this.fireballFlip = !this.fireballFlip;

--- a/games/battle-arena/tools/fx-shots.mjs
+++ b/games/battle-arena/tools/fx-shots.mjs
@@ -73,9 +73,35 @@ const SHOTS = [
     name: "smite",
     champ: "Aurelius",
     ability: "Consecrating Smite",
-    find: "o.isMesh && o.visible && o.material && o.material.uniforms && o.material.uniforms.uProgress && o.material.uniforms.uProgress.value > 0.9",
-    aim: "o.material.uniforms.uTarget.value",
+    // the column, once its front has reached the top and the star has opened
+    find: "o.isMesh && o.visible && o.material && o.material.uniforms && o.material.uniforms.uGrown && o.material.uniforms.uHeight && o.material.uniforms.uGrown.value > 0.99 && o.material.uniforms.uCharge.value < 0.4",
+    aim: "o.material.uniforms.uCentre.value",
     cam: [7, 5, 9],
+  },
+  {
+    name: "grand-hex",
+    champ: "Grimelda",
+    ability: "Grand Hex",
+    // the singularity, settled after its opening swell
+    find: "o.isMesh && o.visible && o.material && o.material.uniforms && o.material.uniforms.uHorizon && o.material.uniforms.uChurn && o.material.uniforms.uChurn.value < 0.05",
+    cam: [6, 2.5, 7],
+  },
+  {
+    name: "cauldron-brew",
+    champ: "Grimelda",
+    ability: "Cauldron Brew",
+    // the pool, once the corrosion has spread to the footprint
+    find: "o.isMesh && o.visible && o.material && o.material.uniforms && o.material.uniforms.uGrown && o.material.uniforms.uSpent && o.material.uniforms.uFront.value < 0.05",
+    cam: [4, 5.5, 5],
+  },
+  {
+    name: "hex-bolt",
+    champ: "Grimelda",
+    ability: "Hex Bolt",
+    // the helix wake behind the bolt, once it has reached back its full span
+    find: "o.isMesh && o.visible && o.material && o.material.uniforms && o.material.uniforms.uSpan && o.material.uniforms.uHead && o.material.uniforms.uSpan.value > 4.4",
+    aim: "o.material.uniforms.uHead.value",
+    cam: [3, 1.5, 3.5],
   },
   {
     name: "seismic-slam",


### PR DESCRIPTION
## Summary

Ports four techniques from [achrefelouafi/LinearAbiltyCastingExtendedThreeJS](https://github.com/achrefelouafi/LinearAbiltyCastingExtendedThreeJS) (MIT) into Battle Arena, re-graded for the arena's toon look, bloom pass and steep camera. Same six champions, same spells — this is a visual upgrade on four of them plus two description rewordings.

| Spell | Before | After | Module |
| --- | --- | --- | --- |
| Aurelius W · Consecrating Smite | lightning bolt from the sky | fluted column of light standing on the mark, a four-pointed star at its head, two counter-tilted halo rings turning about it | `fx-pillar.ts` |
| Grimelda R · Grand Hex | implosion + mushrooms | a singularity tears open over the circle: premultiplied black shadow, beamed photon ring, differentially wound halo (mushrooms kept) | `fx-void.ts` |
| Grimelda W · Cauldron Brew | telegraph disc + bubbles | an acid pool eating the floor: voronoi-crazed stone, bleached channels, world-space relief lighting, Blinn sheen, corroded outline, cell bubbles bursting on their own clocks | `fx-pool.ts` |
| Grimelda Q · Hex Bolt | additive puff trail | a nest of helix ribbons dragged behind the bolt (one instanced draw), dissolving in place when it bursts | `fx-ribbon.ts` |

## Notes

- Everything is pooled and built in world space by the vertex shaders — no per-cast allocations, no CPU paths. All materials read the shared hit-stop clock (`fxClock`) so they freeze with everything else.
- The sandbox's depth prepass soft-fade and screen-space distortion (the black hole's lens, the column's heat warp) are not ported; we have neither pass.
- Gains are far below the sandbox's: under our UnrealBloom (threshold 0.82) its values blow the frame to white. Checked with headless captures through the real `?viewer=1` pipeline.
- The brew pool's outline is held inside the zone radius so the telegraph's hostile rim stays legible.
- `tools/fx-shots.mjs` gains freeze targets for the four new pieces; the smite shot now finds the column instead of the retired bolt.

## Verification

- `pnpm --filter @repo/battle-arena typecheck` / `build` clean
- `oxlint` + `oxfmt --check` clean on the package
- `pnpm --filter @repo/battle-arena test` — 60 passed
- Headless Playwright captures of all four spells through the viewer (swiftshader), iterated on brightness/placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4t8hWaJagiqW6NsrSdBNk

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4t8hWaJagiqW6NsrSdBNk)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports four spell effects from the MIT-licensed extended VFX sandbox into Battle Arena, re-graded for the arena's toon look, bloom pass, and steep camera. Same six champions and spells — visual upgrade only, plus two description rewordings.

**What changed**

| Spell | Before | After |
| --- | --- | --- |
| Aurelius W · Consecrating Smite | lightning bolt from the sky | fluted column of light with a four-pointed star and two counter-tilted halo rings |
| Grimelda R · Grand Hex | implosion + mushrooms | singularity tearing open: premultiplied black shadow, beamed photon ring, wound halo |
| Grimelda W · Cauldron Brew | telegraph disc + bubbles | acid pool eating the floor: voronoi-crazed stone, relief lighting, Blinn sheen, corroded outline, self-timed cell bubbles |
| Grimelda Q · Hex Bolt | additive puff trail | nest of helix ribbons behind the bolt, one instanced draw, dissolving on burst |

**Notes**

- Everything is pooled and built in world space by vertex shaders; no per-cast allocations or CPU paths.
- All materials read the shared hit-stop clock (`fxClock`) so they freeze with everything else.
- The sandbox's depth prepass soft-fade and screen-space distortion are not ported; the arena has neither pass.
- Gains are re-graded for the arena's UnrealBloom (threshold 0.82); the sandbox's values would blow the frame to white.
- The brew pool's outline is held inside the zone radius so the telegraph's hostile rim stays legible.
- `tools/fx-shots.mjs` gains freeze targets for the four new pieces; the smite shot now finds the column.
- Verified: typecheck/build clean, `oxlint` + `oxfmt --check` clean, 60 tests pass, headless Playwright captures through the viewer.

<sup>Written for commit 36be737f13456665191208a9d0ae39eed1eb19b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

