### PR TITLE
Move the consistent-type-definitions disables into one scoped override

### DIFF
--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -18,12 +18,10 @@ import { isJsonOutput, outputArgs, writeJson, writeStructured } from "../lib/out
 import { isJsonNumber, isJsonObject, isJsonString } from "../lib/types.js";
 import type { JsonObject, JsonValue } from "../lib/types.js";
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- an interface has no index signature, so it cannot be an OutputValue
 type DownloadFailure = {
   url: string;
   error: string;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- same: it must satisfy OutputValue
 type FormatMismatch = {
   path: string;
   actual: string;
@@ -33,7 +31,6 @@ type FormatMismatch = {
 // the raw fal payload under `result:` so fal's own keys can't clobber
 // our top-level (action / endpoint_id / request_id). `status` cherry-
 // picks known fields for the same reason.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type ActionFields = {
   status?: string;
   queue_position?: number;
@@ -303,7 +300,6 @@ const runCommand = defineCommand({
   },
 });
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type RunCompletedPayload = {
   status: string;
   endpoint_id: string;
@@ -314,7 +310,6 @@ type RunCompletedPayload = {
   download_format_mismatches?: FormatMismatch[];
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type CodexRunPayload = {
   status: string;
   provider: string;

--- a/games/battle-arena/src/net/snapshot.ts
+++ b/games/battle-arena/src/net/snapshot.ts
@@ -16,7 +16,6 @@ import type {
   World,
 } from "../sim/types";
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type Snapshot = {
   now: number;
   gameTime: number;

--- a/games/battle-arena/src/render/fx-bolt.ts
+++ b/games/battle-arena/src/render/fx-bolt.ts
@@ -271,7 +271,6 @@ void main() {
 
 /** One pass's uniform block. Named rather than an open dictionary so the
  *  colour and vector values keep their types all the way to the write site. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type BoltUniforms = {
   uTime: { value: number };
   uOrigin: { value: THREE.Vector3 };

--- a/games/battle-arena/src/render/fx-pillar.ts
+++ b/games/battle-arena/src/render/fx-pillar.ts
@@ -388,7 +388,6 @@ void main() {
   gl_FragColor = vec4(color, alpha);
 }`;
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type PillarUniforms = {
   uTime: { value: number };
   uCentre: { value: THREE.Vector3 };
@@ -406,7 +405,6 @@ type PillarUniforms = {
   uColorCool: { value: THREE.Color };
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type StarUniforms = {
   uTime: { value: number };
   uCentre: { value: THREE.Vector3 };
@@ -421,7 +419,6 @@ type StarUniforms = {
   uColorCool: { value: THREE.Color };
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type HaloUniforms = {
   uTime: { value: number };
   uOuter: { value: number };

--- a/games/battle-arena/src/render/fx-ribbon.ts
+++ b/games/battle-arena/src/render/fx-ribbon.ts
@@ -219,7 +219,6 @@ const createStripGeometry = (): THREE.InstancedBufferGeometry => {
   return geo;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type RibbonUniforms = {
   uTime: { value: number };
   uHead: { value: THREE.Vector3 };

--- a/games/battle-arena/src/render/fx-void.ts
+++ b/games/battle-arena/src/render/fx-void.ts
@@ -176,7 +176,6 @@ void main() {
   gl_FragColor = vec4(color * (1.0 - shadow), alpha);
 }`;
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type VoidUniforms = {
   uTime: { value: number };
   uSize: { value: number };

--- a/games/battle-arena/src/render/telegraph.ts
+++ b/games/battle-arena/src/render/telegraph.ts
@@ -109,7 +109,6 @@ void main() {
   gl_FragColor = vec4(col, min(a, 1.0));
 }`;
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type DecalUniforms = {
   uColor: THREE.IUniform<THREE.Color>;
   uRim: THREE.IUniform<THREE.Color>;

--- a/games/battle-arena/src/sim/types.ts
+++ b/games/battle-arena/src/sim/types.ts
@@ -19,7 +19,6 @@ export type GamePhase = "lobby" | "playing" | "ended";
 // or shows up to AI/economy/HUD (their filters are hero/creep opt-in).
 export type UnitKind = "hero" | "boss" | "dummy" | "creep" | "prop";
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type AbilitySlot = {
   rank: number;
   readyAt: number;
@@ -58,7 +57,6 @@ export type Status =
   | { kind: "hex"; until: number; pct: number; id?: string };
 
 // ── Unit ─────────────────────────────────────────────────────────────────────
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Unit = {
   id: string;
   kind: UnitKind;
@@ -201,7 +199,6 @@ export type ProjectileHit =
   | { tag: "root"; duration: number }
   | { tag: "burn"; dps: number; duration: number };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Projectile = {
   id: string;
   ownerId: string;
@@ -241,7 +238,6 @@ export type Projectile = {
 };
 
 // ── Ground effects (AoE zones, telegraphs, delayed nukes) ────────────────────
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type GroundEffect = {
   id: string;
   ownerId: string;
@@ -282,7 +278,6 @@ export type GroundEffect = {
 // actually connects (or a jump-attack lands). Plain data — rides snapshots so
 // a host migration can't drop a mid-swing strike. The hit shape re-tests at
 // resolve time, so a scheduled strike is dodgeable.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type PendingStrike = {
   // ms — when the blade/slam connects
   at: number;
@@ -302,7 +297,6 @@ export type PendingStrike = {
 };
 
 // ── Signature-mechanic entities ──────────────────────────────────────────────
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Coin = {
   id: string;
   x: number;
@@ -318,7 +312,6 @@ export type Coin = {
   loot?: boolean;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Delivery = {
   id: string;
   x: number;
@@ -327,7 +320,6 @@ export type Delivery = {
   expireAt: number;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type BossState = {
   x: number;
   y: number;
@@ -379,8 +371,7 @@ export type FxEvent =
   | { t: "notify"; text: string; kind: string };
 
 // ── The World ────────────────────────────────────────────────────────────────
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
-export type World = {
+export interface World {
   // ms host clock
   now: number;
   // s since match start
@@ -417,7 +408,7 @@ export type World = {
   seq: number;
   // mulberry32 state
   rngState: number;
-};
+}
 
 /** Monotonic id within a World. */
 export const nextId = (w: World, prefix: string): string => {

--- a/games/bomberman/src/shared/constants.ts
+++ b/games/bomberman/src/shared/constants.ts
@@ -45,21 +45,18 @@ export type Dir = "up" | "down" | "left" | "right";
 
 export type PowerupKind = "bomb" | "fire" | "speed";
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonRecord needs
 export type Powerup = {
   col: number;
   row: number;
   kind: PowerupKind;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonRecord needs
 export type PlayerStats = {
   bombs: number;
   range: number;
   speed: number;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonRecord needs
 export type Bomb = {
   id: string;
   ownerId: string;
@@ -69,7 +66,6 @@ export type Bomb = {
   range: number;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonRecord needs
 export type Blast = {
   id: string;
   tiles: { col: number; row: number }[];
@@ -80,21 +76,19 @@ export type Blast = {
  * Per-player networked state. `dir`/`moving` let remote clients pick the
  * right walk animation; `col`/`row` are the authoritative grid position.
  */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonRecord needs
-export type PlayerState = {
+export interface PlayerState {
   col: number;
   row: number;
   colorIdx: number;
   dir: Dir;
   moving: boolean;
-};
+}
 
 /**
  * A host-controlled CPU fighter. Lives in shared state (not a real
  * connection), so every client renders it identically and a promoted host
  * keeps driving it. `nextMoveAt` is a host-clock timestamp gating its cadence.
  */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonRecord needs
 export type Bot = {
   id: string;
   col: number;
@@ -110,7 +104,6 @@ export type Bot = {
  * (`{...prev, ...patch}`), so the host always rewrites each nested object
  * wholesale — every field that can reset MUST be present in `emptyShared()`.
  */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonRecord needs
 export type SharedState = {
   grid: Cell[][];
   bombs: Record<string, Bomb>;

--- a/games/crazy-waymo/src/render/sky.ts
+++ b/games/crazy-waymo/src/render/sky.ts
@@ -60,7 +60,6 @@ const HORIZON_WELD_BAND = 0.055;
 const DITHER_RELATIVE = 0.005;
 const DITHER_ABSOLUTE = 0.0034;
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature ShaderMaterial uniforms need
 type SkyUniforms = {
   readonly turbidity: THREE.IUniform<number>;
   readonly rayleigh: THREE.IUniform<number>;

--- a/games/crazy-waymo/src/shared/types.ts
+++ b/games/crazy-waymo/src/shared/types.ts
@@ -58,7 +58,6 @@ export type Solid = {
   );
 
 // A drivable surface patch floating over the terrain (pier deck, bridge ramp).
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type SurfaceDeck = {
   readonly minX: number;
   readonly maxX: number;

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -174,7 +174,6 @@ const boxesOverlap = (a: OccBox, b: OccBox): boolean => {
 
 // A streamed tile of static city geometry: its own merged meshes under one
 // group, tagged with a centre + cull radius so it can be hidden when far away.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type MatRec = {
   color: number;
   roughness: number;

--- a/games/crazy-waymo/src/world/furniture.ts
+++ b/games/crazy-waymo/src/world/furniture.ts
@@ -96,7 +96,6 @@ export interface FurnitureCtx {
   readonly worldZ: (gz: number) => number;
 }
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type ParkedSpec = {
   x: number;
   z: number;
@@ -105,7 +104,6 @@ export type ParkedSpec = {
 };
 // World position of a lamp's light source + the pavement under it — the
 // night-time glow pass (fx/lamp-glow.ts) draws halos and light pools here.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type LampHead = {
   x: number;
   y: number;

--- a/games/crazy-waymo/src/world/parcel-pack.ts
+++ b/games/crazy-waymo/src/world/parcel-pack.ts
@@ -51,7 +51,6 @@ const OBB_STRIDE = 6;
 // x, z, half
 const PILLAR_STRIDE = 3;
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedPlans = {
   readonly count: number;
   /** Ring and centre coordinates are `origin + value * scale`. */
@@ -82,7 +81,6 @@ export type PackedPlans = {
   readonly districts: string[];
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedLots = {
   readonly count: number;
   readonly origin: readonly [number, number];

--- a/games/crazy-waymo/src/world/quantized-geometry.ts
+++ b/games/crazy-waymo/src/world/quantized-geometry.ts
@@ -9,14 +9,12 @@ import * as THREE from "three";
 // three's raycast does, and the ceiling harvest (world/solid-index.ts) scales
 // the raw integers itself. A Float32 copy of a road tile is never made.
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type QPos = {
   q: Uint16Array;
   min: [number, number, number];
   span: [number, number, number];
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type QUv = {
   q: Uint16Array;
   min: [number, number];
@@ -24,7 +22,6 @@ export type QUv = {
 };
 
 /** One static mesh's attributes as they ship: quantized, normals mandatory. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedGeometry = {
   pos: QPos;
   nor: Int8Array;

--- a/games/crazy-waymo/src/world/world-bin.ts
+++ b/games/crazy-waymo/src/world/world-bin.ts
@@ -157,11 +157,10 @@ export type Typed =
   | Int8Array
   | Uint8Array
   | Int32Array;
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
-export type BufRef = {
+export interface BufRef {
   $buf: number;
   $type: "f32" | "u16" | "i16" | "u32" | "i8" | "u8" | "i32";
-};
+}
 
 /** A serialization-tree node: JSON structure with typed arrays at the leaves
  *  (runtime side) or `$buf` refs in their place (wire side). */
@@ -281,7 +280,6 @@ export type PackedTile = PackedGeometry & {
   x: number;
   z: number;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedWorld = {
   tiles: PackedTile[];
 };
@@ -293,7 +291,6 @@ export type PackedMergedChunk = PackedGeometry & {
   mat: MatRec;
   srcMat: { url: string; idx: number } | null;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedRawGeo = {
   pos: QPos;
   nor: Int8Array | null;
@@ -301,7 +298,6 @@ export type PackedRawGeo = {
   index: Uint16Array | Uint32Array | null;
   mat: MatRec;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedBatchItems = {
   urls: string[];
   urlIdx: Int32Array;
@@ -313,7 +309,6 @@ export type PackedBatchItems = {
   tints: Int32Array;
   count: number;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedRest = {
   mergedChunks: PackedMergedChunk[];
   rawGeos: PackedRawGeo[];
@@ -326,7 +321,6 @@ export type PackedRest = {
 
 /** One 320u world tile (shared/constants CHUNK): the merged static geometry
  *  inside it plus the parcel fabric whose centres fall in it. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedWorldTile = {
   ix: number;
   iz: number;
@@ -339,7 +333,6 @@ export type PackedWorldTile = {
   solids: PackedSolids;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type WorldTileRef = {
   ix: number;
   iz: number;
@@ -353,7 +346,6 @@ export type WorldTileRef = {
  *  templates are shared GLB geometry), the base collision boxes (borders,
  *  seawalls, landmarks, furniture — the parcel walls ride their tiles), and
  *  the skyline, which reads from anywhere and is built once. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedMeta = {
   rawGeos: PackedRawGeo[];
   items: PackedBatchItems;
@@ -367,13 +359,11 @@ export type PackedMeta = {
 
 /** A bake's output as one download: each entry is a finished artifact's
  *  bytes (gzipped) under its public/world path. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type BakeFile = {
   name: string;
   data: Uint8Array;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type WorldBinPayload = {
   rev: number;
   world?: PackedWorld;
@@ -487,7 +477,6 @@ export const unpackRawGeos = (p: readonly PackedRawGeo[]): CityRestPayload["rawG
     uv: null,
   }));
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
 export type PackedSolids = {
   data: Float32Array;
   flags: Uint8Array;
@@ -497,8 +486,7 @@ export type PackedSolids = {
 
 // Mutable staging shape for Solid: the flag-gated fields are added one
 // statement at a time, and Solid itself is readonly.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature BinTree needs
-type UnpackedSolid = {
+interface UnpackedSolid {
   minX: number;
   maxX: number;
   minZ: number;
@@ -507,7 +495,7 @@ type UnpackedSolid = {
   yaw?: number;
   noBody?: boolean;
   unseen?: string;
-};
+}
 
 // oxlint-disable-next-line no-bitwise -- the solid flags are a bit set (see packSolidFlags)
 const hasFlag = (flags: number, bit: number): boolean => (flags & bit) !== 0;

--- a/games/lunerfall/src/data/animations.ts
+++ b/games/lunerfall/src/data/animations.ts
@@ -67,12 +67,10 @@ const sliceRanges = (from: number, to: number, n: number): [number, number][] =>
   return out;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type AseFrame = {
   filename: string;
   duration: number;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type AseData = {
   frames: AseFrame[];
   meta: { frameTags: { name: string; from: number; to: number }[] };

--- a/games/lunerfall/src/net/snapshot.ts
+++ b/games/lunerfall/src/net/snapshot.ts
@@ -8,7 +8,6 @@
 import { isJsonObject } from "./json";
 import type { JsonValue } from "./json";
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type NetPlayer = {
   id: string;
   hero: string;
@@ -32,7 +31,6 @@ export type NetPlayer = {
 
 // Enemies/boss travel as the clip the host is already playing (read after its
 // render) so the guest just re-plays it — no state-enum re-derivation, no drift.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type NetEnemy = {
   id: number;
   name: string;
@@ -43,7 +41,6 @@ export type NetEnemy = {
   dead: boolean;
   flash: boolean;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type NetBoss = {
   clip: string;
   x: number;
@@ -58,7 +55,6 @@ export type NetBoss = {
 // Guest → host input. Held state travels as booleans; each action carries a
 // monotonic counter so a press is never lost even if the net tick is slower than
 // the frame rate (the host derives an edge when a counter increments).
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type NetInput = {
   left: boolean;
   right: boolean;
@@ -70,7 +66,6 @@ export type NetInput = {
   a: number;
   s: number;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type NetProj = {
   k: "arrow" | "shot" | "hazard";
   x: number;
@@ -81,7 +76,6 @@ export type NetProj = {
 // Co-op last stand: broadcast while a player is downed. bleed = seconds left on
 // the bleed-out clock; rev = 0..1 revive-hold progress. Which player is downed
 // travels on NetPlayer.downed; both clients render the marker from these.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type NetLastStand = {
   bleed: number;
   rev: number;
@@ -90,7 +84,6 @@ export type NetLastStand = {
 // Online versus: the match state, broadcast every snapshot while in versus mode.
 // Sides are fixed (host = left duelist, guest = right) so hearts/scores never
 // need a player-id mapping on either client.
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type NetVersus = {
   phase: "waiting" | "countdown" | "fighting" | "roundEnd" | "matchEnd";
   // 1-based; 0 while waiting for the challenger
@@ -105,7 +98,6 @@ export type NetVersus = {
   winner: "host" | "guest" | null;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type Snapshot = {
   // host frame counter — interpolation + stall detection
   t: number;
@@ -128,7 +120,6 @@ export type Snapshot = {
 };
 
 // Full room layout — sent once per room (not per frame).
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type NetDoor = {
   index: number;
   x: number;
@@ -137,7 +128,6 @@ export type NetDoor = {
   label: string;
   danger: boolean;
 };
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type NetRoom = {
   seq: number;
   // "coop" | "vs" — versus arenas mirror the guest spawn, no doors

--- a/games/moba/src/net/snapshot.ts
+++ b/games/moba/src/net/snapshot.ts
@@ -6,7 +6,6 @@ import type { MultiplayerClient } from "@vibedgames/multiplayer";
 
 import type { FxEvent, GroundEffect, Mine, Projectile, Unit, World } from "../sim/types";
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type Snapshot = {
   now: number;
   gameTime: number;

--- a/games/moba/src/sim/math.ts
+++ b/games/moba/src/sim/math.ts
@@ -1,7 +1,6 @@
 // Pure 2D vector + geometry helpers shared by the simulation and renderer.
 // No Phaser imports — this stays runnable in plain node for tests/headless sim.
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Vec2 = {
   x: number;
   y: number;

--- a/games/moba/src/sim/types.ts
+++ b/games/moba/src/sim/types.ts
@@ -68,7 +68,6 @@ export type Order =
   | { type: "fountain" };
 
 // ---- hero / creep / structure detail --------------------------------------
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type AbilitySlot = {
   rank: number;
   // ms host-clock when off cooldown
@@ -76,7 +75,6 @@ export type AbilitySlot = {
   // transient per-cast bookkeeping handled in abilities.ts
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type ChannelState = {
   effect: string;
   key: AbilityKey;
@@ -86,7 +84,6 @@ export type ChannelState = {
   point: Vec2;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type HeroState = {
   defId: string;
   // multiplayer connection id, or "bot:<n>"
@@ -129,7 +126,6 @@ export type HeroState = {
   botRetreating: boolean;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type CreepState = {
   ckind: CreepKind;
   lane: LaneId;
@@ -144,7 +140,6 @@ export type CreepState = {
   boss?: boolean;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type StructureState = {
   tier: StructTier;
   lane: LaneId | "base";
@@ -157,7 +152,6 @@ export type StructureState = {
 };
 
 // ---- the unit --------------------------------------------------------------
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Unit = {
   id: string;
   kind: UnitKind;
@@ -219,7 +213,6 @@ export type Unit = {
 };
 
 // ---- projectiles -----------------------------------------------------------
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Projectile = {
   id: string;
   ownerId: string;
@@ -328,7 +321,6 @@ export const rand = (w: World): number => {
 };
 /* oxlint-enable no-bitwise, unicorn/prefer-math-trunc */
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Mine = {
   id: string;
   ownerId: string;
@@ -342,7 +334,6 @@ export type Mine = {
   slowPct: number;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type GroundEffect = {
   id: string;
   ownerId: string;

--- a/games/starfall/src/shared/constants.ts
+++ b/games/starfall/src/shared/constants.ts
@@ -1406,7 +1406,6 @@ export const BEACON_CONTEST_STROBE_HZ = 4;
 /** BEACON shared entry — the ONE nullable SharedState field the event adds
  *  (~90B on the wire). Six scalars, host-written; clients derive phase +
  *  countdown locally: t < activeAt → CHARGE, else ACTIVE until diesAt. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type BeaconState = {
   x: number;
   y: number;
@@ -1694,13 +1693,11 @@ export const MINIMAP_PAD = 12;
 
 // ---- shared/networked types ----------------------------------------------------
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type Vec = {
   x: number;
   y: number;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type AsteroidState = {
   id: string;
   x: number;
@@ -1715,7 +1712,6 @@ export type AsteroidState = {
   rot: number;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type UfoState = {
   id: string;
   x: number;
@@ -1743,7 +1739,6 @@ export type ItemState = {
   diesAt: number;
 } & ItemDrop;
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type EnemyState = {
   id: string;
   kind: EnemyKind;
@@ -1772,7 +1767,6 @@ export type EnemyState = {
   shielded: boolean;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type EnemyShotState = {
   id: string;
   x: number;
@@ -1785,7 +1779,6 @@ export type EnemyShotState = {
 /** SINGULARITY pull: until `until` (epoch-ms) the HOST drags asteroids +
  *  enemies within SINGULARITY_PULL_RANGE of (x,y) toward it; every client
  *  renders the vortex from this entry. Pruned by the host on expiry. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type PullState = {
   id: string;
   x: number;
@@ -1794,7 +1787,6 @@ export type PullState = {
 };
 
 /** Score shard: host-owned, drifts, +SHARD_SCORE on touch, 8s lifetime. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type ShardState = {
   id: string;
   x: number;
@@ -1810,7 +1802,6 @@ export type ShardState = {
  * resettable key MUST be present in `emptyShared()` and the host rewrites each
  * top-level field wholesale.
  */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type SharedState = {
   asteroids: AsteroidState[];
   ufo: UfoState | null;
@@ -1840,7 +1831,6 @@ export type SharedState = {
 };
 
 /** Beam snapshot in another player's state — drawn raw, never simulated. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type SerializedBeam = {
   hx: number;
   hy: number;
@@ -1865,7 +1855,6 @@ export type SerializedBeam = {
   power?: number;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type ShieldModNetState = {
   kind: ShieldModKind;
   /** Epoch-ms expiry of the 20s mod window. */
@@ -1876,14 +1865,12 @@ export type ShieldModNetState = {
   phased: boolean;
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- type alias keeps the implicit index signature JsonValue needs
 export type BoostNetState = {
   kind: BoosterKind;
   until: number;
 };
 
 /** Per-player networked state (each client writes its own at 20Hz). */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type PlayerNetState = {
   x: number;
   y: number;

--- a/games/starfall/src/trailer/trailer-director.ts
+++ b/games/starfall/src/trailer/trailer-director.ts
@@ -95,7 +95,6 @@ interface Bolt {
 type CrewMode = "idle" | "combat" | "duel";
 
 /** The peer-state keys a real client serializes — what readNetState consumes. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 type PeerNetState = {
   x: number;
   y: number;

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -4,6 +4,43 @@ import core from "ultracite/oxlint/core";
 import react from "ultracite/oxlint/react";
 import tanstack from "ultracite/oxlint/tanstack";
 
+// Modules whose payload types must stay `type X = { ... }`. TypeScript grants
+// a type alias an implicit index signature but never an interface — declaration
+// merging can add members later, so the compiler cannot assume an interface's
+// keys. Everything declared here is handed to a JSON-shaped index-signature
+// type (`OutputValue`, `MessageData`, `JsonValue`, `JsonRecord`, world-bin's
+// wire trees, a `ShaderMaterial` uniform map), which an interface cannot
+// satisfy. The escape the rule pushes toward — `[key: string]: unknown` on
+// every interface — is strictly worse: it admits any key at all and discards
+// the exact payloads these unions exist to enforce.
+const jsonPayloadModules = [
+  "apps/cli/src/commands/generate.ts",
+  "games/battle-arena/src/net/snapshot.ts",
+  "games/battle-arena/src/render/fx-bolt.ts",
+  "games/battle-arena/src/render/fx-pillar.ts",
+  "games/battle-arena/src/render/fx-ribbon.ts",
+  "games/battle-arena/src/render/fx-void.ts",
+  "games/battle-arena/src/render/telegraph.ts",
+  "games/battle-arena/src/sim/types.ts",
+  "games/bomberman/src/shared/constants.ts",
+  "games/crazy-waymo/src/render/sky.ts",
+  "games/crazy-waymo/src/shared/types.ts",
+  "games/crazy-waymo/src/world/city.ts",
+  "games/crazy-waymo/src/world/furniture.ts",
+  "games/crazy-waymo/src/world/parcel-pack.ts",
+  "games/crazy-waymo/src/world/quantized-geometry.ts",
+  "games/crazy-waymo/src/world/world-bin.ts",
+  "games/lunerfall/src/data/animations.ts",
+  "games/lunerfall/src/net/snapshot.ts",
+  "games/moba/src/net/snapshot.ts",
+  "games/moba/src/sim/math.ts",
+  "games/moba/src/sim/types.ts",
+  "games/starfall/src/shared/constants.ts",
+  "games/starfall/src/trailer/trailer-director.ts",
+  "packages/asset-tools/src/sprite/size-contract.ts",
+  "packages/embed/src/protocol.ts",
+];
+
 export default defineConfig({
   extends: [core, react, antiSlop],
   ignorePatterns: [
@@ -18,10 +55,16 @@ export default defineConfig({
     "sandbox",
     "**/scripts/_lib/**",
   ],
-  overrides: tanstack.overrides.map((override) => ({
-    ...override,
-    files: override.files.map((glob) => `apps/web/${glob}`),
-  })),
+  overrides: [
+    ...tanstack.overrides.map((override) => ({
+      ...override,
+      files: override.files.map((glob) => `apps/web/${glob}`),
+    })),
+    {
+      files: jsonPayloadModules,
+      rules: { "typescript/consistent-type-definitions": "off" },
+    },
+  ],
   rules: {
     // Sequential awaits in loops are deliberate here (rate-limited source reads, ordered writes).
     "no-await-in-loop": "off",

--- a/packages/asset-tools/src/sprite/size-contract.ts
+++ b/packages/asset-tools/src/sprite/size-contract.ts
@@ -38,7 +38,6 @@ export const DEFAULT_TOLERANCES: Tolerances = {
   maxWidthOverflowPct: 0.12,
 };
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type Measurement = {
   frame: string;
   source: string;
@@ -58,7 +57,6 @@ export interface EmptySummary {
   frameSize: null;
 }
 
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type PopulatedSummary = {
   frames: number;
   nonEmptyFrames: number;

--- a/packages/embed/src/protocol.ts
+++ b/packages/embed/src/protocol.ts
@@ -7,19 +7,16 @@ export const PAUSE_GAME_MESSAGE = "vibedgames:pause-game";
 export const GAME_PAUSED_MESSAGE = "vibedgames:game-paused";
 
 /** Game → wrapper: active play began (or resumed) — hide the wrapper chrome. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type GameStartedMessage = {
   readonly type: typeof GAME_STARTED_MESSAGE;
 };
 
 /** Wrapper → game: the player asked for the wrapper back — pause the game. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type PauseGameMessage = {
   readonly type: typeof PAUSE_GAME_MESSAGE;
 };
 
 /** Game → wrapper: the game paused itself (Escape) — show the wrapper chrome. */
-// oxlint-disable-next-line typescript/consistent-type-definitions -- must stay assignable to the JSON index-signature type; interfaces get no implicit index signature
 export type GamePausedMessage = {
   readonly type: typeof GAME_PAUSED_MESSAGE;
 };


### PR DESCRIPTION
The repo carried 93 `oxlint-disable-next-line typescript/consistent-type-definitions` comments across 25 files, each asserting the declaration had to stay a `type` alias.

## Verified, not trusted

Every site was probed in isolation: convert the alias to an `interface`, drop the comment, run that package's `tsc --noEmit`.

- **89 genuine.** Each one breaks typecheck as an interface — TypeScript gives a type alias an implicit index signature but never an interface (declaration merging can add members later), so `interface Foo {}` is not assignable to `{ [key: string]: Json }` while `type Foo = {}` is. The failures are concrete: `OutputValue` in `apps/cli/src/lib/output.ts`, `MessageData` in `packages/embed/src/protocol.ts`, `JsonValue`/`JsonRecord` in the game sim shared types, world-bin's wire trees, and Three.js `ShaderMaterial` uniform maps. Transitive cases count too — `DownloadFailure` is only reachable as `DownloadFailure[]` inside `RunCompletedPayload`, and an intersection like `type StatusPayload = ActionFields & { ... }` loses the index signature the moment `ActionFields` becomes an interface.
- **4 cargo-culted.** `World` (battle-arena/sim), `PlayerState` (bomberman), `BufRef` and `UnpackedSolid` (crazy-waymo/world-bin) never reach a JSON boundary. They are now interfaces and their comments are gone.

## The change

The 89 remaining sites collapse into a single `overrides` entry in `oxlint.config.ts` naming the 25 specific files — no `**/*` glob — carrying the reason once. Same shape as ultracite's own anti-slop preset, which turns three core rules off with one comment where two rules pinch each other. All 93 per-line comments are deleted.

Nothing was widened to satisfy the rule: adding `[key: string]: unknown` to these interfaces would admit any key at all and discard the exact payload shapes these unions exist to enforce, which is why the override is the right lever rather than a type change.

## Verification

- `pnpm exec oxlint` — 0
- `pnpm exec oxlint --report-unused-disable-directives` — 0, no dead directives left
- `pnpm verify` — green (typecheck, lint, format, 381 tests)
- `pnpm build` — green
- Removing one glob from the override reproduces the three `protocol.ts` errors, confirming the entry is load-bearing rather than decorative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces 93 per-line `typescript/consistent-type-definitions` disables across 25 files with a single scoped override in `oxlint.config.ts` that turns the rule off for those specific files and carries the reason once. Four of the 93 disables were cargo-culted — `World`, `PlayerState`, `BufRef`, and `UnpackedSolid` never reach a JSON boundary — so they are now plain `interface`s.

**Notes**
- The 89 remaining types must stay aliases: TypeScript gives a type alias an implicit index signature but never an interface, so an interface cannot satisfy the JSON-shaped index-signature types these payloads are assigned to.
- Widening those interfaces with `[key: string]: unknown` instead would admit any key and discard the exact payload shapes these unions exist to enforce.
- The override names the 25 files explicitly — no `**/*` glob — matching how ultracite's anti-slop preset handles rule pinches.
- `oxlint` reports 0 errors and 0 unused disable directives; `verify` and `build` pass. Removing one file from the override reproduces the typecheck failures, confirming it's load-bearing.

<sup>Written for commit 43a60da16c3ea9f15303b905a0746354e750cbb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

