### PR TITLE
Drop two lint directives that no longer suppress anything

### DIFF
--- a/games/bomberman/tools/two-client.mjs
+++ b/games/bomberman/tools/two-client.mjs
@@ -3,7 +3,6 @@
 // rotation), host migration and a late join. Needs the party server on
 // localhost:8787 and Chrome. `--url http://localhost:5304` reuses a dev server;
 // otherwise a vite instance is spawned on --port (default 5384).
-/* eslint-disable no-underscore-dangle */
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";

--- a/games/lunerfall/src/data/run-recap.ts
+++ b/games/lunerfall/src/data/run-recap.ts
@@ -1,7 +1,7 @@
 import { HERO_NAMES } from "./animations";
 import type { HeroName } from "./animations";
 
-/* oxlint-disable anti-slop/no-unknown-parameters, anti-slop/no-runtime-typeof -- This module is the parser for untyped Phaser scene-entry data. */
+/* oxlint-disable anti-slop/no-unknown-parameters -- This module is the parser for untyped Phaser scene-entry data. */
 
 type Reached = Readonly<{ hero: HeroName; biome: number; depth: number; gold: number }>;
 


### PR DESCRIPTION
`oxlint --report-unused-disable-directives` flagged both after #327 landed.

- `games/lunerfall/src/data/run-recap.ts` listed two rules; only `anti-slop/no-unknown-parameters` still fires, so `no-runtime-typeof` came off the list and the rest of the directive stays.
- `games/bomberman/tools/two-client.mjs` carried an `eslint-disable`, and this repo has no eslint.

Verified: `pnpm verify` green, zero errors and zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes obsolete lint directives from the Bomberman tool and Lunerfall parser so lint configuration matches the rules enforced by this repository.

- Retains the parser’s `anti-slop/no-unknown-parameters` suppression while dropping only the unused `anti-slop/no-runtime-typeof` rule.
- Removes the stale ESLint directive from `two-client.mjs`; `pnpm verify` passes with zero errors and warnings.

<sup>Written for commit bfd6d0af394ee5767470d88b9d66d2d3147311aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

