### PR TITLE
Fix the three start-screen warts left by the chrome cleanup

### DIFF
--- a/games/bomberman/src/scenes/game-scene.ts
+++ b/games/bomberman/src/scenes/game-scene.ts
@@ -907,6 +907,8 @@ export class GameScene extends Scene {
       // undiscoverable before the first touch.
       visible: "coarse",
     });
+    // Gameplay chrome: nothing but the start card until play begins.
+    this.gamepad.setVisible(false);
 
     // Touch path to restart (R has no on-screen equivalent): while dead or
     // after the round ends, any fresh tap restarts. The arming delay stops
@@ -2125,6 +2127,7 @@ export class GameScene extends Scene {
     // started, over the one overlay that teaches the controls.
     unlockAudio();
     this.touchControls = createTouchControls();
+    this.gamepad.setVisible(true);
     notifyGameStarted();
     this.startEl?.classList.add("hide");
     if (this.startEl) {

--- a/games/crazy-waymo/index.html
+++ b/games/crazy-waymo/index.html
@@ -993,12 +993,9 @@
       body.chatting #touch.on.play {
         display: none;
       }
-      /* The shared @repo/embed pause/mute cluster owns the top-right corner on
-         a touch device; the cards that live there start below it. */
+      /* The shared @repo/embed pause button owns the top-right corner on a
+         touch device; the cards that live there start below it. */
       @media (pointer: coarse) {
-        #netinfo {
-          top: calc(76px + env(safe-area-inset-top));
-        }
         #fare-card {
           top: calc(98px + env(safe-area-inset-top));
         }
@@ -1096,6 +1093,12 @@
       }
       #netinfo:empty {
         display: none;
+      }
+      /* Below the shared pause button; must follow the base rule to win. */
+      @media (pointer: coarse) {
+        #netinfo {
+          top: calc(76px + env(safe-area-inset-top));
+        }
       }
     </style>
     <script>

--- a/games/moba/src/scenes/menu-scene.ts
+++ b/games/moba/src/scenes/menu-scene.ts
@@ -495,10 +495,18 @@ export class MenuScene extends Scene {
       action.ring.setVisible(this.focus.kind === "action" && this.focus.action === action);
     }
     if (this.navigationHint) {
-      const text =
-        this.focus.kind === "champion"
-          ? "Choose a champion · arrows / D-pad · Enter / A"
-          : `${this.focus.action.online ? "PLAY ONLINE" : "PLAY vs BOTS"} · Enter / A to play · ↑ to return`;
+      // A phone without a pad has no arrows or Enter to point at.
+      const tapOnly =
+        window.matchMedia("(pointer: coarse)").matches && !(this.pad?.connected ?? false);
+      let text: string;
+      if (this.focus.kind === "champion") {
+        text = tapOnly
+          ? "Choose a champion · tap to pick"
+          : "Choose a champion · arrows / D-pad · Enter / A";
+      } else {
+        const play = this.focus.action.online ? "PLAY ONLINE" : "PLAY vs BOTS";
+        text = tapOnly ? `${play} · tap to play` : `${play} · Enter / A to play · ↑ to return`;
+      }
       this.navigationHint.setText(text).setScale(1);
       this.navigationHint.setScale(
         Math.min(1, (this.scale.width - 32) / Math.max(1, this.navigationHint.width)),

--- a/packages/gamepad/README.md
+++ b/packages/gamepad/README.md
@@ -116,8 +116,9 @@ if (dir) this.step(dir);
 
 The Phaser adapter draws the joystick + fixed buttons into a screen-fixed
 `Graphics` object. Tune it with `render: { depth, tint, blendMode }`, recolor at
-runtime with `setTint(0xff00aa)`, or pass `render: false` and draw it yourself
-from `gamepad.pad` (see `getStickGeometry`, `getStick`, `getButtonLayout`).
+runtime with `setTint(0xff00aa)`, hide it behind a start screen with
+`setVisible(false)` (input keeps working), or pass `render: false` and draw it
+yourself from `gamepad.pad` (see `getStickGeometry`, `getStick`, `getButtonLayout`).
 
 ## Framework-agnostic core
 

--- a/packages/gamepad/src/dom.ts
+++ b/packages/gamepad/src/dom.ts
@@ -44,6 +44,9 @@ export interface DomGamepad {
   justReleased: (id: string) => boolean;
   /** Recolor the knob + buttons (CSS color). */
   setTint: (color: string) => void;
+  /** Hide the overlay regardless of `visible` policy — e.g. behind a start
+   *  screen — and bring it back. Input keeps working while hidden. */
+  setVisible: (visible: boolean) => void;
   /** Call once per frame from your game loop: publishes press edges and
    *  redraws the overlay. */
   update: () => void;
@@ -203,6 +206,7 @@ export const attachDomGamepad = (options: DomGamepadOptions = {}): DomGamepad =>
   const policy = options.visible ?? "touch";
   const renderOpts = options.render === false ? null : (options.render ?? {});
   let isTouch = false;
+  let visible = true;
   let tint = renderOpts?.tint ?? "#fff";
   let destroyed = false;
 
@@ -275,10 +279,13 @@ export const attachDomGamepad = (options: DomGamepadOptions = {}): DomGamepad =>
     setTint(color) {
       tint = color;
     },
+    setVisible(next) {
+      visible = next;
+    },
     update() {
       pad.reconcile(live);
       pad.nextFrame();
-      view?.draw(pad, tint, isTouch || preShow(policy));
+      view?.draw(pad, tint, visible && (isTouch || preShow(policy)));
     },
   };
 };

--- a/packages/gamepad/src/phaser.ts
+++ b/packages/gamepad/src/phaser.ts
@@ -47,6 +47,9 @@ export interface PhaserGamepad {
   justReleased: (id: string) => boolean;
   /** Recolor the knob + buttons (e.g. to the local player's color). */
   setTint: (color: number) => void;
+  /** Hide the overlay regardless of `visible` policy — e.g. behind a start
+   *  screen — and bring it back. Input keeps working while hidden. */
+  setVisible: (visible: boolean) => void;
   /** Call once per frame from your scene's `update()`: reconciles stale
    *  pointers and publishes press edges. The overlay redraws itself at render
    *  time, so this can be called as early in the frame as the game likes. */
@@ -173,6 +176,7 @@ export const attachVirtualGamepad = (
   const policy = options.visible ?? "touch";
   const renderOpts = options.render === false ? null : (options.render ?? {});
   let tint = renderOpts?.tint ?? 0xff_ff_ff;
+  let visible = true;
 
   scene.input.addPointer(options.extraPointers ?? Math.max(2, (options.buttons?.length ?? 0) + 2));
 
@@ -233,7 +237,7 @@ export const attachVirtualGamepad = (
     const pin = screenSpaceTransform(cameraView(scene.cameras.main));
     gfx.setPosition(pin.x, pin.y).setRotation(pin.rotation).setScale(pin.scale);
     gfx.clear();
-    const show = isTouch || preShow(policy);
+    const show = visible && (isTouch || preShow(policy));
     if (show) {
       drawGamepad(gfx, pad, tint);
     }
@@ -273,6 +277,9 @@ export const attachVirtualGamepad = (
     pad,
     setTint: (color) => {
       tint = color;
+    },
+    setVisible: (next) => {
+      visible = next;
     },
     update() {
       const live: number[] = [];


### PR DESCRIPTION
Follow-up to #336.

- **bomberman**: the virtual bomb pad showed behind the start blur. It is drawn in-canvas by `@vibedgames/gamepad`'s Phaser renderer, so CSS could not gate it. Both renderers gain an additive `setVisible(boolean)` (input keeps working while hidden); bomberman hides the pad until `beginPlay`. README updated. Needs a gamepad patch release for external users; in-repo games resolve source.
- **crazy-waymo**: "N ONLINE" overlapped ⏸ on phones. The `@media (pointer: coarse)` offset was declared before the base `#netinfo` rule and lost the cascade. Moved after it; computed top is now 76px under a coarse pointer.
- **moba**: champion-select hint read "arrows / D-pad · Enter / A" on touch. Now "tap to pick" / "tap to play" on a coarse pointer with no pad connected.

Verified headlessly (iPhone 14, real touch): bomberman start card shows no pad, pad appears after the first tap; moba hint reads "tap to pick"; waymo netinfo computed offset 76px. `pnpm verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM9tKhTfFbGEhjL6WBPGBR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three start-screen visual bugs left by the chrome cleanup: the bomberman bomb pad peeking through the start blur, Crazy Waymo's "N ONLINE" overlapping the pause button on phones, and Mobas champion-select hint lying to touch players about arrows and Enter.

**What changed**
- Added `setVisible(bool)` to both gamepad renderers in `@vibedgames/gamepad`; input keeps working while hidden, and bomberman hides the pad until play begins.
- Fixed Crazy Waymo's netinfo offset by moving its coarse-pointer rule after the base rule so the cascade applies it.
- Moba now shows "tap to pick" / "tap to play" instead of keyboard/gamepad hints when the pointer is coarse and no pad is connected.
- External users of `@vibedgames/gamepad` need a patch release to get `setVisible`; in-repo games resolve source directly.

<sup>Written for commit 7d52338bdff1c75bb4324bd859fbaf6fbdad73b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

