### PR TITLE
Align mobile game chrome: centred cards, bottom-right cameras, one pause

### DIFF
--- a/games/flappy-dragons/src/scenes/game-scene.ts
+++ b/games/flappy-dragons/src/scenes/game-scene.ts
@@ -1346,27 +1346,28 @@ export class GameScene extends Scene {
       return;
     }
     this.resultLayoutKey = key;
-    let cardWidth = width;
     let x = this.scale.width / 2;
     let y = Math.min(
       this.scale.height - height - 16,
       this.scale.height / 2 + (this.scale.height <= 520 ? 30 : 48),
     );
-    // Overlapping the camera: sit beside it when there's room, else above it.
+    // Overlapping the camera: sit beside it only when the FULL card fits in
+    // the space to its left (desktop); otherwise stay centred and rise above
+    // it. Shrinking the card to fit beside a phone's thumbnail pushed the
+    // whole results screen off-centre for a few pixels of camera.
     if (camera && x + width / 2 > camera.left && y + height > camera.top - 12) {
-      if (camera.left >= 272) {
-        cardWidth = Math.min(width, camera.left - 32);
+      if (camera.left - 32 >= width) {
         x = camera.left / 2;
       } else {
         y = Math.max(90, Math.min(y, camera.top - height - 16));
       }
     }
-    card.style.width = `${cardWidth}px`;
+    card.style.width = `${width}px`;
     card.style.left = `${x}px`;
     card.style.top = `${y}px`;
     const zoom = this.viewZoom();
     this.overImg
-      .setScale(Math.min(ART_SCALE, (cardWidth - 16) / zoom / this.overImg.width))
+      .setScale(Math.min(ART_SCALE, (width - 16) / zoom / this.overImg.width))
       .setPosition(x / zoom, this.viewTop() + (y - 48) / zoom);
   }
 

--- a/games/pong/index.html
+++ b/games/pong/index.html
@@ -301,6 +301,14 @@
       body:not(.vg-started) #camera-panel {
         display: none;
       }
+      /* Pre-serve the card IS the start screen, so it sits mid-screen: the
+         wrapper page keeps its own chrome over the frame's bottom edge until
+         play begins, and a bottom-anchored card disappeared under it. */
+      body:not(.vg-started) #banner {
+        top: 50%;
+        bottom: auto;
+        transform: translate(-50%, -50%);
+      }
 
       /* Ink-on-paper skin for @repo/embed's touch pause button — the one
          control that is keyboard-only everywhere else. */
@@ -324,8 +332,10 @@
         color: inherit;
         font: inherit;
         position: fixed;
-        right: calc(14px + env(safe-area-inset-right));
-        bottom: calc(14px + env(safe-area-inset-bottom));
+        /* Bottom-right, 12px in from the safe area — the one camera-panel
+           anchor every camera game shares. */
+        right: calc(12px + env(safe-area-inset-right));
+        bottom: calc(12px + env(safe-area-inset-bottom));
         /* Clamped for phones off the SHORT side: 34vw is right in portrait but
            a landscape phone is 850+px wide, where the full 224px panel covers
            the player's own paddle at full right deflection. */
@@ -341,10 +351,21 @@
         outline: 3px solid #000;
         outline-offset: 5px;
       }
-      /* Narrow (portrait phone): sit above the #serve-meter zone. */
+      /* Narrow (portrait phone): the full-width serve card and the serve
+         meter would run under the panel, so THEY rise above it (the panel
+         keeps the shared bottom-right anchor). Panel height = 3/4 of its
+         width plus the 2px borders; a folded pill is 44px. */
       @media (max-width: 600px) {
-        #camera-panel {
-          bottom: calc(80px + env(safe-area-inset-bottom));
+        body.vg-started :is(#banner, #serve-meter) {
+          bottom: calc(28px + env(safe-area-inset-bottom) + 0.75 * min(224px, 34vmin));
+        }
+        body.vg-started:has(
+            #camera-panel[data-min="1"],
+            #camera-panel[data-state="off"],
+            #camera-panel[data-state="error"]
+          )
+          :is(#banner, #serve-meter) {
+          bottom: calc(68px + env(safe-area-inset-bottom));
         }
       }
       /* A landscape phone has no room in the bottom-right: the player's paddle

--- a/games/tetris/index.html
+++ b/games/tetris/index.html
@@ -382,8 +382,10 @@
          grayscale feed, selfie-mirrored (video + skeleton overlay together). */
       #camera-panel {
         position: fixed;
-        right: 10px;
-        bottom: 10px;
+        /* Bottom-right, 12px in from the safe area — the one camera-panel
+           anchor every camera game shares. */
+        right: calc(12px + env(safe-area-inset-right, 0px));
+        bottom: calc(12px + env(safe-area-inset-bottom, 0px));
         width: 300px;
         height: 225px;
         border-radius: 10px;
@@ -526,17 +528,20 @@
         }
       }
 
-      /* Small or touch screens: shrink the webcam panel to a thumbnail pinned
-         top-right (bottom-right belongs to the button cluster); tap toggles an
-         expanded view. Pose stays fully live at every size. */
+      /* Small or touch screens: shrink the webcam panel to a thumbnail; tap
+         toggles an expanded view. Pose stays fully live at every size. It keeps
+         the shared bottom-right anchor; on touch, where the thumb cluster owns
+         the corner itself, it stacks directly above the cluster on the same
+         right edge (284px = three rows of buttons from the safe-area corner,
+         plus a 12px gap). */
       @media (max-width: 700px), (max-height: 550px), (pointer: coarse) {
         #camera-panel {
-          top: calc(env(safe-area-inset-top, 0px) + 156px);
-          bottom: auto;
-          right: calc(env(safe-area-inset-right, 0px) + 10px);
           width: 120px;
           height: 90px;
           cursor: pointer;
+        }
+        body.touch #camera-panel {
+          bottom: calc(env(safe-area-inset-bottom, 0px) + 296px);
         }
         #camera-panel.expanded {
           width: 240px;
@@ -557,13 +562,12 @@
           font-size: 11px;
         }
       }
-      /* Landscape phone: the thumbnail shares the right edge with the pause
-         button above it and the thumb buttons below, so it insets past the
-         button's column and expands only within the band between them. */
+      /* Landscape phone: the cluster folds to two rows (196px tall from the
+         safe-area corner), so the thumbnail sits that much higher and expands
+         only within the band it has left. */
       @media (max-height: 550px) {
-        #camera-panel {
-          top: calc(env(safe-area-inset-top, 0px) + 48px);
-          right: calc(env(safe-area-inset-right, 0px) + 64px);
+        body.touch #camera-panel {
+          bottom: calc(env(safe-area-inset-bottom, 0px) + 208px);
         }
         #camera-panel.expanded {
           width: 152px;
@@ -574,13 +578,12 @@
           height: 44px;
         }
       }
-      /* Keep teaching / results below the expanded feed on narrow screens. */
       @media (max-width: 700px) and (min-height: 551px) {
-        /* A live feed is opaque: leave the well's spawn height visible while
-           playing / catching, without cropping the 4:3 camera image. */
+        /* A live feed is opaque: keep the expanded view small enough to leave
+           the well's spawn height visible while playing / catching, without
+           cropping the 4:3 camera image. */
         body:has(#banner[data-phase="playing"]) #camera-panel.expanded,
         body:has(#banner[data-phase="collapsing"]) #camera-panel.expanded {
-          top: calc(env(safe-area-inset-top, 0px) + 70px);
           width: 180px;
           height: 135px;
         }
@@ -588,10 +591,6 @@
           --banner-top: max(260px, 32vh);
           top: var(--banner-top);
           padding: 0 16px;
-        }
-        body:has(#camera-panel.expanded) #banner {
-          --banner-top: max(350px, 39vh);
-          top: var(--banner-top);
         }
         #spatial-rule {
           padding: 10px 12px;

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -31,6 +31,11 @@ re-sends `game-started` so the wrapper can tuck its chrome away again.
 
 Everything no-ops when the game runs standalone (not in an iframe).
 
+`createTouchControls()` is the one piece that runs the other way round: the
+touch-only pause button mounts only when the game is standalone on a coarse
+pointer. Inside the wrapper the wrapper's own pause button covers the action,
+so nothing mounts and the game keeps its top-right corner.
+
 ## Overlays that a tap dismisses
 
 Any full-screen overlay a player taps away — the pause overlay, a game's own

--- a/packages/embed/src/game.ts
+++ b/packages/embed/src/game.ts
@@ -34,6 +34,13 @@ let listening = false;
 
 const embedded = (): boolean => typeof window !== "undefined" && window.parent !== window;
 
+/**
+ * Whether the game runs inside a wrapper page (the vibedgames play view) rather
+ * than standalone at its own origin. The wrapper owns chrome the game must not
+ * duplicate — its own pause button, for one.
+ */
+export const isEmbedded = (): boolean => embedded();
+
 /** Escape must not steal keystrokes from text entry (chat boxes, name fields). */
 const isTypingTarget = (target: EventTarget | null): boolean =>
   target instanceof HTMLElement &&

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -13,6 +13,7 @@ export type {
   ControlsManifest,
 } from "./controls";
 export {
+  isEmbedded,
   isPausable,
   notifyGameStarted,
   pauseGame,

--- a/packages/embed/src/touch-controls.ts
+++ b/packages/embed/src/touch-controls.ts
@@ -1,9 +1,14 @@
 // The one control a phone player has no other way to reach.
 //
-// Pause is Escape-bound (./game), so on a coarse pointer a session cannot be
-// paused at all. Everything else a paused player might want — sound on/off,
-// controls, help — lives on the pause overlay itself (./pause-shell), so this
-// stays a single button that only exists while a pause would actually work.
+// Pause is Escape-bound (./game), so on a coarse pointer a STANDALONE session
+// cannot be paused at all. Everything else a paused player might want — sound
+// on/off, controls, help — lives on the pause overlay itself (./pause-shell),
+// so this stays a single button that only exists while a pause would actually
+// work.
+//
+// Embedded in the wrapper page, nothing mounts: the wrapper draws its own pause
+// button over the frame, and a second one in the game's top-right corner was
+// a duplicate control that also cost every game its top-right HUD corner.
 //
 // This is a shared affordance rather than eleven bespoke HUD buttons: it is the
 // same action everywhere, it has to clear the notch and the home indicator
@@ -11,7 +16,7 @@
 // through `className`/`css` and the CSS custom properties below.
 
 import { isCoarsePointer } from "./controls";
-import { isPausable, pauseGame, watchPausable } from "./game";
+import { isEmbedded, isPausable, pauseGame, watchPausable } from "./game";
 import { PAUSE_OVERLAY_Z } from "./pause-shell";
 import { sealPointerEvents } from "./pointer-seal";
 
@@ -123,10 +128,16 @@ const reserveCorner = (root: HTMLElement): void => {
 /**
  * Mount the touch-only pause button. No-op on a fine pointer, so calling it
  * unconditionally at boot is correct — a desktop player keeps Escape and sees
- * nothing.
+ * nothing. Also a no-op inside the wrapper page, whose own pause button
+ * covers the same action; `--vg-touch-reserve` then stays unset (0px) and the
+ * game keeps its whole top edge.
  */
 export const createTouchControls = (options: TouchControlsOptions = {}): TouchControls => {
   if (typeof document === "undefined" || !isCoarsePointer()) {
+    return { destroy: noop };
+  }
+  // Pause is the cluster's only button, so with it gone nothing else mounts.
+  if (options.pause === false || isEmbedded()) {
     return { destroy: noop };
   }
 
@@ -165,22 +176,19 @@ export const createTouchControls = (options: TouchControlsOptions = {}): TouchCo
   // `pauseGame()` no-ops until the game announces it started, so a pause button
   // rendered on the start screen is a dead control — it looks tappable and does
   // nothing. Show it only while it would actually work.
-  let unwatchPausable: (() => void) | null = null;
-  if (options.pause !== false) {
-    const pauseEl = button("Pause", "⏸", () => pauseGame());
-    const drawPause = (): void => {
-      pauseEl.hidden = !isPausable();
-    };
-    drawPause();
-    unwatchPausable = watchPausable(drawPause);
-  }
+  const pauseEl = button("Pause", "⏸", () => pauseGame());
+  const drawPause = (): void => {
+    pauseEl.hidden = !isPausable();
+  };
+  drawPause();
+  const unwatchPausable = watchPausable(drawPause);
 
   document.body.append(root);
   reserveCorner(root);
 
   return {
     destroy: () => {
-      unwatchPausable?.();
+      unwatchPausable();
       root.remove();
       document.documentElement.style.removeProperty(RESERVE_VAR);
     },


### PR DESCRIPTION
## What

Fixes the mobile layout bugs from the phone screenshots (pong start card hidden under wrapper chrome, flappy game-over card off-centre, camera panels in different corners, duplicate pause buttons).

### One pause, not two
- `@repo/embed` `createTouchControls()` now no-ops when the game runs inside the wrapper (`isEmbedded()`, newly exported). The wrapper already draws its own pause button, so the in-game top-right one was a duplicate that also cost every game its top-right HUD corner.
- Standalone on a phone (`{slug}.vibedgames.com`) it still mounts: it is the only way to pause there, and the sound toggle lives on the pause overlay.
- Applies to all games at once since every game mounts through this one helper.

### Camera panels share one anchor
- Bottom-right, `12px` in from the safe area, across pong, flappy-dragons, pacman and tetris.
- **Pong** was 14px and lifted 80px on phones. Now the serve card and serve meter rise above the panel on narrow screens instead (panel height derived in CSS; 44px when folded to a pill). Landscape-phone top-left rule kept, since the paddle sweeps the bottom edge there.
- **Tetris** sat top-right on touch. Now it stacks directly above the thumb cluster on the same right edge (296px up on tall screens, 208px on landscape phones). Dropped the banner push-down rules that only existed for the top-anchored feed.
- Pacman and flappy already used this anchor; no change.

### Cards centred
- **Pong** pre-serve card is centred (`body:not(.vg-started) #banner`). The wrapper keeps its nav over the frame's bottom edge until play starts, so the bottom-anchored card was covered.
- **Flappy** game-over card only sits beside the camera when the full card fits in the space to its left (desktop). On a phone it stays centred and rises above the panel; before, `camera.left >= 272` shrank it to 245px and pushed it left.

## Verification
- `tsc --noEmit` clean in embed, flappy-dragons, pong, tetris, pacman; `pnpm lint` and `pnpm format` clean; embed pause-key smoke test passes.
- Rendered pong, flappy and tetris in headless Chromium at 393×852 with touch emulation, inside an iframe with a viewport meta (embedded) and standalone: pong start card centred, in-play camera pill at 12px/12px, no top-right pause embedded and present standalone; flappy results card at x 26.5–366.5 (centred) above the camera pill; tetris camera pill 296px up on the right edge above the cluster.

## Notes
- The wrapper's own pause button is bottom-left (`game-chrome.tsx`), not bottom-right. Left as is so it doesn't collide with the camera panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeHBxyaDR2U4AZuQf8rxP1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeHBxyaDR2U4AZuQf8rxP1)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile layout bugs across the camera games: duplicate pause buttons, camera panels in different corners, and cards hidden or off-centre on phone screens.

- `@repo/embed`'s touch pause button no longer mounts inside the wrapper, which draws its own; standalone games on phones still get it since it's the only way to pause there.
- Camera panels now anchor bottom-right, 12px in from the safe area, across pong, flappy-dragons, pacman, and tetris.
- Pong's pre-serve card is centred instead of bottom-anchored, where the wrapper's chrome covered it until play starts.
- Flappy's game-over card stays centred on phones; it only sits beside the camera when the full card fits to its left.
- Tetris' camera thumbnail stacks above its thumb cluster on the same right edge on touch screens.

<sup>Written for commit 001b008c220845d75868a5b2db3168fe53f22145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

