### PR TITLE
Payload types outside games/ become interfaces

### DIFF
--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -18,25 +18,22 @@ import { isJsonOutput, outputArgs, writeJson, writeStructured } from "../lib/out
 import { isJsonNumber, isJsonObject, isJsonString } from "../lib/types.js";
 import type { JsonObject, JsonValue } from "../lib/types.js";
 
-type DownloadFailure = {
-  url: string;
-  error: string;
-};
-type FormatMismatch = {
-  path: string;
-  actual: string;
-};
+// One source of truth for the download shapes: they are `downloadMedia`'s own
+// result, not a second copy that can drift from it.
+type DownloadOutcome = Awaited<ReturnType<typeof downloadMedia>>;
+type DownloadFailure = DownloadOutcome["failed"][number];
+type FormatMismatch = DownloadOutcome["mislabeled"][number];
 
 // Action-specific fields for the status-command payload. `result` wraps
 // the raw fal payload under `result:` so fal's own keys can't clobber
 // our top-level (action / endpoint_id / request_id). `status` cherry-
 // picks known fields for the same reason.
-type ActionFields = {
+interface ActionFields {
   status?: string;
   queue_position?: number;
   logs?: JsonValue;
   result?: JsonValue;
-};
+}
 
 const buildActionFields = (
   action: "status" | "result" | "cancel",
@@ -160,8 +157,6 @@ const runViaCodex = async (opts: {
     process.exit(1);
   }
 };
-type DownloadOutcome = Awaited<ReturnType<typeof downloadMedia>>;
-
 const buildRunPayload = (
   endpointId: string,
   completed: { request_id: string; result: JsonValue },
@@ -300,7 +295,7 @@ const runCommand = defineCommand({
   },
 });
 
-type RunCompletedPayload = {
+interface RunCompletedPayload {
   status: string;
   endpoint_id: string;
   request_id: string;
@@ -308,9 +303,9 @@ type RunCompletedPayload = {
   downloaded_files?: string[];
   download_failures?: DownloadFailure[];
   download_format_mismatches?: FormatMismatch[];
-};
+}
 
-type CodexRunPayload = {
+interface CodexRunPayload {
   status: string;
   provider: string;
   endpoint_id: string;
@@ -319,7 +314,7 @@ type CodexRunPayload = {
   downloaded_files: string[];
   download_failures?: DownloadFailure[];
   ignored_references?: string[];
-};
+}
 
 // ---- status -----------------------------------------------------------------
 
@@ -466,15 +461,14 @@ const statusCommand = defineCommand({
   },
 });
 
-// A type alias, not an interface: it must stay assignable to the JSON index-signature type.
-type StatusPayload = ActionFields & {
+interface StatusPayload extends ActionFields {
   action: "status" | "result" | "cancel";
   endpoint_id: string;
   request_id: string;
   downloaded_files?: string[];
   download_failures?: DownloadFailure[];
   download_format_mismatches?: FormatMismatch[];
-};
+}
 
 // ---- models -----------------------------------------------------------------
 

--- a/apps/cli/src/lib/output.ts
+++ b/apps/cli/src/lib/output.ts
@@ -31,6 +31,19 @@ interface OutputObject {
   [key: string]: OutputValue;
 }
 
+/**
+ * What a command may hand to `writeStructured`: a JSON value, or a payload
+ * type declared member by member.
+ *
+ * The second arm exists because TypeScript grants an implicit index signature
+ * only to a type alias, never to an interface — declaration merging could add
+ * members later, so an interface's keys are never assumed and it is not
+ * assignable to `OutputValue`'s object arm. Mapping the payload's own keys
+ * checks each one against `OutputValue` instead, which still rejects a `Date`
+ * or a method where `[key: string]: unknown` on every payload would not.
+ */
+type OutputPayload<T> = OutputValue | { [K in keyof T]: OutputValue };
+
 const isOutputObject = (value: OutputValue): value is OutputObject =>
   // Object() is the identity only on objects; arrays are split off explicitly.
   Object(value) === value && !Array.isArray(value);
@@ -107,7 +120,10 @@ export const formatField = (value: OutputValue): string => {
  * value is the more specific request. Returns false when neither flag was
  * given, so the caller can fall through to its human-readable rendering.
  */
-export const writeStructured = (value: OutputValue, args: OutputArgs): boolean => {
+export const writeStructured = <T extends OutputPayload<T>>(
+  value: T,
+  args: OutputArgs,
+): boolean => {
   if (args.field) {
     const selected = selectField(value, args.field);
     if (selected === undefined) {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -4,17 +4,18 @@ import core from "ultracite/oxlint/core";
 import react from "ultracite/oxlint/react";
 import tanstack from "ultracite/oxlint/tanstack";
 
-// Modules whose payload types must stay `type X = { ... }`. TypeScript grants
-// a type alias an implicit index signature but never an interface — declaration
-// merging can add members later, so the compiler cannot assume an interface's
-// keys. Everything declared here is handed to a JSON-shaped index-signature
-// type (`OutputValue`, `MessageData`, `JsonValue`, `JsonRecord`, world-bin's
-// wire trees, a `ShaderMaterial` uniform map), which an interface cannot
-// satisfy. The escape the rule pushes toward — `[key: string]: unknown` on
-// every interface — is strictly worse: it admits any key at all and discards
-// the exact payloads these unions exist to enforce.
+// Game modules whose payload types must stay `type X = { ... }`. TypeScript
+// grants a type alias an implicit index signature but never an interface —
+// declaration merging can add members later, so the compiler cannot assume an
+// interface's keys. Everything declared here is handed to a JSON-shaped
+// index-signature type (`JsonValue`, `JsonRecord`, world-bin's wire trees, a
+// `ShaderMaterial` uniform map), which an interface cannot satisfy. The escape
+// the rule pushes toward — `[key: string]: unknown` on every interface — is
+// strictly worse: it admits any key at all and discards the exact payloads
+// these unions exist to enforce. Each game is independent, so each one carries
+// its own entries; the fix outside `games/` was to make the consuming boundary
+// generic over the payload type instead.
 const jsonPayloadModules = [
-  "apps/cli/src/commands/generate.ts",
   "games/battle-arena/src/net/snapshot.ts",
   "games/battle-arena/src/render/fx-bolt.ts",
   "games/battle-arena/src/render/fx-pillar.ts",
@@ -44,8 +45,6 @@ const jsonPayloadModules = [
   "games/moba/src/sim/types.ts",
   "games/starfall/src/shared/constants.ts",
   "games/starfall/src/trailer/trailer-director.ts",
-  "packages/asset-tools/src/sprite/size-contract.ts",
-  "packages/embed/src/protocol.ts",
 ];
 
 export default defineConfig({

--- a/packages/asset-tools/src/sprite/size-contract.ts
+++ b/packages/asset-tools/src/sprite/size-contract.ts
@@ -38,7 +38,7 @@ export const DEFAULT_TOLERANCES: Tolerances = {
   maxWidthOverflowPct: 0.12,
 };
 
-export type Measurement = {
+export interface Measurement {
   frame: string;
   source: string;
   frameSize: [number, number];
@@ -48,7 +48,7 @@ export type Measurement = {
   visibleHeight?: number;
   visibleCenterX?: number;
   visibleBottomY?: number;
-};
+}
 
 /** No visible pixels anywhere — nothing to measure beyond the frame count. */
 export interface EmptySummary {
@@ -57,7 +57,7 @@ export interface EmptySummary {
   frameSize: null;
 }
 
-export type PopulatedSummary = {
+export interface PopulatedSummary {
   frames: number;
   nonEmptyFrames: number;
   frameSize: [number, number] | null;
@@ -72,7 +72,7 @@ export type PopulatedSummary = {
   maxVisibleWidth: number;
   maxVisibleHeight: number;
   intraHeightDriftPct: number | null;
-};
+}
 
 export type Summary = EmptySummary | PopulatedSummary;
 
@@ -506,6 +506,19 @@ export const loadSizeContract = (payload: JsonValue, source: string): SizeContra
   };
 };
 
+/**
+ * Widen a measured payload into the JSON domain.
+ *
+ * Every member of these payloads is JSON, but TypeScript grants an implicit
+ * index signature only to a type alias, never to an interface — declaration
+ * merging could add members later, so an interface's keys are never assumed
+ * and it is not assignable to `JsonValue`. Mapping a type parameter over its
+ * own keys checks the members instead, which keeps the exact payload typing
+ * that `JsonValue`'s "any key at all" index signature would discard.
+ */
+const asJson = <T extends { [K in keyof T]: JsonValue | undefined }>(value: T | T[]): JsonValue =>
+  value;
+
 export const deriveSizeContract = (
   source: string,
   options: {
@@ -548,8 +561,8 @@ export const deriveSizeContract = (
     direction,
     kind: "sprite-size-contract",
     maxVisibleWidth: summary.maxVisibleWidth,
-    measurements,
-    measurementsSummary: summary,
+    measurements: asJson(measurements),
+    measurementsSummary: asJson(summary),
     name: name ?? path.basename(source).replace(/\.[^.]+$/u, ""),
     pivot,
     promptGuidance: promptGuidanceForContract({

--- a/packages/embed/src/protocol.ts
+++ b/packages/embed/src/protocol.ts
@@ -7,19 +7,19 @@ export const PAUSE_GAME_MESSAGE = "vibedgames:pause-game";
 export const GAME_PAUSED_MESSAGE = "vibedgames:game-paused";
 
 /** Game → wrapper: active play began (or resumed) — hide the wrapper chrome. */
-export type GameStartedMessage = {
+export interface GameStartedMessage {
   readonly type: typeof GAME_STARTED_MESSAGE;
-};
+}
 
 /** Wrapper → game: the player asked for the wrapper back — pause the game. */
-export type PauseGameMessage = {
+export interface PauseGameMessage {
   readonly type: typeof PAUSE_GAME_MESSAGE;
-};
+}
 
 /** Game → wrapper: the game paused itself (Escape) — show the wrapper chrome. */
-export type GamePausedMessage = {
+export interface GamePausedMessage {
   readonly type: typeof GAME_PAUSED_MESSAGE;
-};
+}
 
 /** What `MessageEvent.data` can carry over this protocol — plain JSON. */
 export type MessageData =
@@ -30,14 +30,22 @@ export type MessageData =
   | MessageData[]
   | { [key: string]: MessageData };
 
-const hasType = (value: MessageData, type: string): boolean =>
-  value instanceof Object && !Array.isArray(value) && value.type === type;
+/** The one field every message on this protocol carries. */
+interface TaggedMessage {
+  readonly type: string;
+}
 
-export const isGameStartedMessage = (value: MessageData): value is GameStartedMessage =>
+// The guards take `unknown` because a message crosses an origin boundary: the
+// sender is free to post anything, so nothing about `event.data` is known until
+// this has picked the tag out of it.
+const hasType = (value: unknown, type: string): value is TaggedMessage =>
+  value instanceof Object && !Array.isArray(value) && "type" in value && value.type === type;
+
+export const isGameStartedMessage = (value: unknown): value is GameStartedMessage =>
   hasType(value, GAME_STARTED_MESSAGE);
 
-export const isPauseGameMessage = (value: MessageData): value is PauseGameMessage =>
+export const isPauseGameMessage = (value: unknown): value is PauseGameMessage =>
   hasType(value, PAUSE_GAME_MESSAGE);
 
-export const isGamePausedMessage = (value: MessageData): value is GamePausedMessage =>
+export const isGamePausedMessage = (value: unknown): value is GamePausedMessage =>
   hasType(value, GAME_PAUSED_MESSAGE);

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -15,6 +15,8 @@ const buttonVariants = cva(
         // disabled fill) so a loading button still reads as primary.
         className:
           "disabled:bg-primary disabled:text-primary-foreground [&>:first-child]:bg-primary",
+        loading: true,
+        variant: "default",
       },
       { className: "[&>:first-child]:bg-destructive/10", loading: true, variant: "destructive" },
       { className: "[&>:first-child]:bg-background", loading: true, variant: "outline" },

--- a/plugins/asset-pipeline/skills/animated-spritesheets/scripts/_lib/asset-tools.mjs
+++ b/plugins/asset-pipeline/skills/animated-spritesheets/scripts/_lib/asset-tools.mjs
@@ -3141,6 +3141,7 @@ var loadSizeContract = (payload, source) => {
     tolerances: mergedTolerances
   };
 };
+var asJson = (value) => value;
 var deriveSizeContract = (source, options = {}) => {
   const {
     cellSize = [FRAME_WIDTH, FRAME_HEIGHT],
@@ -3167,8 +3168,8 @@ var deriveSizeContract = (source, options = {}) => {
     direction,
     kind: "sprite-size-contract",
     maxVisibleWidth: summary.maxVisibleWidth,
-    measurements,
-    measurementsSummary: summary,
+    measurements: asJson(measurements),
+    measurementsSummary: asJson(summary),
     name: name ?? path5.basename(source).replace(/\.[^.]+$/u, ""),
     pivot,
     promptGuidance: promptGuidanceForContract({


### PR DESCRIPTION
`oxlint.config.ts` turned `typescript/consistent-type-definitions` off for 32
modules. Those payload types are declared `type X = { ... }` because TypeScript
grants a type alias an implicit index signature but never an interface —
declaration merging could add members later — and each one is handed to a
JSON-shaped index-signature type.

The three entries outside `games/` no longer need the escape. In each case the
friction was a *consuming boundary* demanding assignability to a bare
`{ [k: string]: Json }`; making that boundary check the payload's own members
instead removes the need without adding `[key: string]: unknown` to anything.

### `apps/cli/src/commands/generate.ts`

`writeStructured` is now generic over
`OutputValue | { [K in keyof T]: OutputValue }`. The mapped arm checks each
declared member against `OutputValue`, so an interface passes — and a `Date`,
a `Map`, or a method is still rejected, which an index signature would not be.
`DownloadFailure` / `FormatMismatch` were duplicates of `downloadMedia`'s own
result shape; they are now indexed accesses into it, which removes the drift
risk and the two lint errors at once.

### `packages/embed/src/protocol.ts`

The three message types are interfaces; the guards take `unknown`. A
postMessage crosses an origin boundary, so `event.data` genuinely is unknown
until a guard has checked it — these functions *are* the parse step. `hasType`
became a guard for `{ readonly type: string }` so it satisfies
`anti-slop/no-unknown-parameters` too. The added `"type" in value` check is
behaviour-preserving (a missing key already compared `undefined`).

### `packages/asset-tools/src/sprite/size-contract.ts`

`Measurement` and `PopulatedSummary` are interfaces. `SizeContract`'s fields
stay `JsonValue` — the file is hand-edited, and narrowing them would be a lie —
so the two derive sites go through one documented `asJson` widening whose
constraint checks members rather than requiring an index signature.

### Verification

- `pnpm exec oxlint --report-unused-disable-directives` — zero errors, zero warnings
- `pnpm verify` green, `pnpm build` green
- All 29 remaining `games/*` entries proven still load-bearing: removing them
  produces 99 `consistent-type-definitions` errors spread across exactly those
  29 files, none missing. Restored, the lint is silent again.

No `games/*` file is touched and no shared helper is introduced for them — each
game stays independent. `jsonPayloadModules` is now 29 paths, all under
`games/`, and the comment says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts the three payload modules outside `games/` to interfaces by moving the JSON index-signature constraint to each consuming boundary, and narrows `oxlint.config.ts`'s `consistent-type-definitions` exemption to 29 `games/*` paths.

**Refactors**
- `writeStructured` is generic over `OutputValue | { [K in keyof T]: OutputValue }`, so a member-wise check still rejects a `Date` or a method.
- `DownloadFailure` and `FormatMismatch` now index into `downloadMedia`'s own result type instead of duplicating its shape.
- `protocol.ts` guards take `unknown` and check `"type" in value`, since `event.data` is unknown until a guard parses it.
- `size-contract.ts` widens its two derive sites through one documented `asJson`.

**Bug Fixes**
- Restores `loading: true` and `variant: "default"` on `Button`'s primary compound variant, which the lint pass dropped so `cva` matched unconditionally and tinted every button's first child with the primary background.

<sup>Written for commit 5c1b188b41f3c381a17017396d661d2ea9e6e1b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

