### PR TITLE
Guard the shared ignore-pattern spread

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -50,7 +50,7 @@ const jsonPayloadModules = [
 export default defineConfig({
   extends: [core, react, antiSlop],
   ignorePatterns: [
-    ...core.ignorePatterns,
+    ...(core.ignorePatterns ?? []),
     "*.generated.ts",
     "dist-electron",
     ".wxt",


### PR DESCRIPTION
`ultracite` types `OxlintConfig.ignorePatterns` as `string[] | undefined`, so spreading it bare is unsound — `TS2488: Type 'string[] | undefined' must have a '[Symbol.iterator]()'`. It passes here only because `oxlint.config.ts` sits in no tsconfig program and is never typechecked. That is luck, not correctness, and it breaks the moment anyone adds the file to a program.

The other fourteen repos already carry the guard. This was the last one; it was skipped in the earlier sweep because the working tree had in-flight work at the time.

Behaviourally a no-op: `core.ignorePatterns` resolves to a real array at runtime, so `?? []` never fires.

Verified with all `tsbuildinfo` caches deleted, since a warm one makes `tsc` report a false pass: lint zero errors and zero warnings, typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the spread of `core.ignorePatterns` in `oxlint.config.ts` so the config typechecks when included in a tsconfig program. `ultracite` types it as `string[] | undefined`, so the old bare spread passed only because the file was never typechecked; `?? []` is a runtime no-op but makes the types sound. This was the last repo without the guard.

<sup>Written for commit b21f9dd7f7700abf87d7440856b0db507dbe582f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

