### PR TITLE
crazy-waymo: retry WebGL context creation, surface the browser's reason

### DIFF
--- a/games/crazy-waymo/src/main.ts
+++ b/games/crazy-waymo/src/main.ts
@@ -57,7 +57,7 @@ const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-const probeCanvas = (): { canvas: HTMLCanvasElement; reason: () => string } => {
+const probeCanvas = () => {
   const canvas = document.createElement("canvas");
   let reason = "";
   canvas.addEventListener("webglcontextcreationerror", (event: Event) => {

--- a/games/crazy-waymo/src/main.ts
+++ b/games/crazy-waymo/src/main.ts
@@ -86,9 +86,15 @@ const createRenderer = async (): Promise<THREE.WebGLRenderer> => {
       await sleep(350 * (i + 1));
     }
   }
+  // Chrome blocks WebGL for a domain for the rest of the browser session once
+  // a page has crashed the GPU process twice; only a full browser restart
+  // clears it, so a retry offer would be a lie.
+  const blocked = /blocked/iu.test(reason);
   showFatal(
-    `WebGL unavailable${reason ? ` (${reason})` : ""} — tap to retry, or enable hardware acceleration.`,
-    true,
+    blocked
+      ? "Chrome blocked graphics for this site after a crash. Close Chrome fully (swipe it away from recents), reopen it, and come back."
+      : `WebGL unavailable${reason ? ` (${reason})` : ""} — tap to retry, or enable hardware acceleration.`,
+    !blocked,
   );
   throw lastError instanceof Error ? lastError : new Error("WebGL init failed");
 };

--- a/games/crazy-waymo/src/main.ts
+++ b/games/crazy-waymo/src/main.ts
@@ -47,14 +47,52 @@ const hideFatal = (): void => {
 // the aliasing, and skipping the resolve pass buys real GPU time. Desktop
 // keeps MSAA exactly as before.
 const msaa = !(isCoarsePointer() && (window.devicePixelRatio || 1) >= 2);
-let renderer: THREE.WebGLRenderer;
-try {
-  renderer = new THREE.WebGLRenderer({ antialias: msaa, powerPreference: "high-performance" });
-} catch (error) {
-  console.error("[crazy-waymo] WebGL init failed", error);
-  showFatal("WebGL unavailable — try a different browser or enable hardware acceleration.");
-  throw error instanceof Error ? error : new Error("WebGL init failed");
-}
+// Context creation fails transiently on phones: Chrome's GPU process was just
+// restarted (a background tab reclaimed it) or the page hit the per-process
+// context cap. Retrying after a beat recovers those; the last attempt drops
+// the high-performance / MSAA asks, which a blocklisted or low-power GPU may
+// refuse outright. The browser's own reason is captured so the veil can show it.
+const sleep = (ms: number): Promise<void> =>
+  // oxlint-disable-next-line promise/avoid-new -- wraps the setTimeout callback API
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+const probeCanvas = (): { canvas: HTMLCanvasElement; reason: () => string } => {
+  const canvas = document.createElement("canvas");
+  let reason = "";
+  canvas.addEventListener("webglcontextcreationerror", (event: Event) => {
+    if (event instanceof WebGLContextEvent && event.statusMessage) {
+      reason = event.statusMessage;
+    }
+  });
+  return { canvas, reason: () => reason };
+};
+const createRenderer = async (): Promise<THREE.WebGLRenderer> => {
+  const attempts: THREE.WebGLRendererParameters[] = [
+    { antialias: msaa, powerPreference: "high-performance" },
+    { antialias: msaa, powerPreference: "high-performance" },
+    { antialias: false, powerPreference: "default" },
+  ];
+  let reason = "";
+  let lastError: unknown;
+  for (const [i, params] of attempts.entries()) {
+    const probe = probeCanvas();
+    try {
+      return new THREE.WebGLRenderer({ ...params, canvas: probe.canvas });
+    } catch (error) {
+      lastError = error;
+      reason = probe.reason() || reason;
+      console.error(`[crazy-waymo] WebGL init attempt ${i + 1} failed`, reason || error);
+      await sleep(350 * (i + 1));
+    }
+  }
+  showFatal(
+    `WebGL unavailable${reason ? ` (${reason})` : ""} — tap to retry, or enable hardware acceleration.`,
+    true,
+  );
+  throw lastError instanceof Error ? lastError : new Error("WebGL init failed");
+};
+const renderer = await createRenderer();
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.shadowMap.enabled = true;


### PR DESCRIPTION
Phones fail `new WebGLRenderer()` transiently — Chrome's GPU process was just restarted after a background tab reclaimed it, or the page hit the per-process context cap. The game showed a dead "WebGL unavailable" veil on the first failure.

Now: three attempts with a growing pause (350/700/1050 ms), the last without `high-performance`/MSAA for blocklisted GPUs; `webglcontextcreationerror.statusMessage` is captured and shown; the veil is tap-to-retry.

Verified headless: normal boot unchanged; permanent failure shows the message with retry; fail-twice-then-succeed boots normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM9tKhTfFbGEhjL6WBPGBR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient WebGL context failures instead of showing the fatal "WebGL unavailable" veil after the first failed `new WebGLRenderer()` call. It makes three attempts with 350/700/1050 ms delays, drops MSAA and the high-performance preference on the final attempt, and surfaces the browser's failure reason on the veil. When Chrome has blocked WebGL for the domain after a GPU crash, the veil shows that specific message without a retry action, since only a full browser restart clears the block.

<sup>Written for commit 7424f1abb82acb3bcb1140314d475090938955ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

