### PR TITLE
crazy-waymo: ship Rapier as wasm, keep the spawn, cache the world in Cache Storage

### DIFF
--- a/apps/games/src/index.ts
+++ b/apps/games/src/index.ts
@@ -15,12 +15,14 @@ import {
 /**
  * Content types R2 stores raw and Cloudflare's edge compression does not cover.
  * Rigged GLBs are the expensive case: they are plain binary buffers that gzip to
- * roughly a third, and an asset-heavy game ships a dozen megabytes of them.
+ * roughly a third, an asset-heavy game ships a dozen megabytes of them, and a
+ * physics engine's wasm shrinks to 40% (streaming instantiation reads the
+ * decoded bytes, so `application/wasm` survives the encoding).
  * Types that arrive already compressed (images, audio, video, and the gzipped
  * `.bin` world payloads games bake themselves) are deliberately absent — a
  * second pass costs CPU and returns nothing.
  */
-const COMPRESSIBLE_TYPES = new Set(["model/gltf-binary", "model/gltf+json"]);
+const COMPRESSIBLE_TYPES = new Set(["model/gltf-binary", "model/gltf+json", "application/wasm"]);
 
 const acceptsGzip = (request: Request): boolean =>
   (request.headers.get("accept-encoding") ?? "").toLowerCase().includes("gzip");

--- a/games/crazy-waymo/package.json
+++ b/games/crazy-waymo/package.json
@@ -3,6 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "imports": {
+    "#rapier": {
+      "node": "./src/physics/rapier-node.ts",
+      "default": "./src/physics/rapier-browser.ts"
+    }
+  },
   "scripts": {
     "build": "vite build",
     "clean": "rm -rf .turbo dist node_modules",
@@ -16,7 +22,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dimforge/rapier3d-compat": "^0.20.0",
+    "@dimforge/rapier3d": "0.20.0",
     "@repo/embed": "workspace:*",
     "@vibedgames/gamepad": "workspace:^",
     "@vibedgames/multiplayer": "workspace:^",
@@ -25,6 +31,7 @@
     "three": "^0.185.1"
   },
   "devDependencies": {
+    "@dimforge/rapier3d-compat": "^0.20.0",
     "@gltf-transform/core": "^4.4.2",
     "@gltf-transform/extensions": "^4.4.2",
     "@kyh/tsconfig": "catalog:",
@@ -33,6 +40,7 @@
     "playwright-core": "^1.62.1",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vite-node": "^6.0.0"
+    "vite-node": "^6.0.0",
+    "vite-plugin-wasm": "^3.6.0"
   }
 }

--- a/games/crazy-waymo/src/fx/cones.ts
+++ b/games/crazy-waymo/src/fx/cones.ts
@@ -1,4 +1,4 @@
-import type { RigidBody } from "@dimforge/rapier3d-compat";
+import type { RigidBody } from "#rapier";
 import * as THREE from "three";
 
 import type { ModelCache } from "../assets/loader";

--- a/games/crazy-waymo/src/fx/surface-fx.ts
+++ b/games/crazy-waymo/src/fx/surface-fx.ts
@@ -1,4 +1,4 @@
-import type { DynamicRayCastVehicleController } from "@dimforge/rapier3d-compat";
+import type { DynamicRayCastVehicleController } from "#rapier";
 
 import type { WheelSurface } from "../world/land-class";
 

--- a/games/crazy-waymo/src/game/parked-cars.ts
+++ b/games/crazy-waymo/src/game/parked-cars.ts
@@ -1,4 +1,4 @@
-import type { RigidBody } from "@dimforge/rapier3d-compat";
+import type { RigidBody } from "#rapier";
 import * as THREE from "three";
 
 import { geoLayoutKey } from "../assets/loader";

--- a/games/crazy-waymo/src/game/traffic-car.ts
+++ b/games/crazy-waymo/src/game/traffic-car.ts
@@ -1,4 +1,4 @@
-import type { RigidBody } from "@dimforge/rapier3d-compat";
+import type { RigidBody } from "#rapier";
 import * as THREE from "three";
 
 import { ROAD_Y } from "../shared/constants";

--- a/games/crazy-waymo/src/physics/physics-world.ts
+++ b/games/crazy-waymo/src/physics/physics-world.ts
@@ -1,5 +1,5 @@
-import { ColliderDesc, init, RigidBodyDesc, RigidBodyType, World } from "@dimforge/rapier3d-compat";
-import type { Collider, RigidBody } from "@dimforge/rapier3d-compat";
+import { ColliderDesc, ready, RigidBodyDesc, RigidBodyType, World } from "#rapier";
+import type { Collider, RigidBody } from "#rapier";
 import type * as THREE from "three";
 
 import { WORLD_H, WORLD_HALF_X, WORLD_HALF_Z, WORLD_W } from "../shared/constants";
@@ -80,7 +80,7 @@ export class PhysicsWorld {
   private streamZ = Infinity;
 
   static async create(): Promise<PhysicsWorld> {
-    await init();
+    await ready();
     return new PhysicsWorld();
   }
 

--- a/games/crazy-waymo/src/physics/rapier-browser.ts
+++ b/games/crazy-waymo/src/physics/rapier-browser.ts
@@ -1,0 +1,8 @@
+// `#rapier` in the browser (package.json "imports", default condition): the
+// raw-wasm build. vite-plugin-wasm turns its wasm import into a streamed
+// fetch, so the 2 MB module is a cacheable asset the browser compiles off the
+// main thread instead of a base64 string parsed inside the JS bundle. It is
+// instantiated at import, so there is nothing to await.
+export * from "@dimforge/rapier3d";
+
+export const ready = (): Promise<void> => Promise.resolve();

--- a/games/crazy-waymo/src/physics/rapier-node.ts
+++ b/games/crazy-waymo/src/physics/rapier-node.ts
@@ -1,0 +1,8 @@
+// `#rapier` under Node (package.json "imports", node condition — vite-node's
+// SSR resolve): the compat build inlines its wasm, so the sim tools run
+// without a wasm loader. Same version and API as the browser build.
+import { init } from "@dimforge/rapier3d-compat";
+
+export * from "@dimforge/rapier3d-compat";
+
+export const ready = (): Promise<void> => init();

--- a/games/crazy-waymo/src/physics/static-solid.ts
+++ b/games/crazy-waymo/src/physics/static-solid.ts
@@ -1,4 +1,4 @@
-import { ColliderDesc } from "@dimforge/rapier3d-compat";
+import { ColliderDesc } from "#rapier";
 import type { Solid } from "../shared/types";
 
 const STATIC_HALF_HEIGHT = 6;

--- a/games/crazy-waymo/src/scenes/game-scene.ts
+++ b/games/crazy-waymo/src/scenes/game-scene.ts
@@ -1,4 +1,5 @@
-import { choosePlayerSpawn } from "../world/player-spawn";
+import { choosePlayerSpawn, isPlayerSpawnSafe } from "../world/player-spawn";
+import type { PlayerSpawn } from "../world/player-spawn";
 import * as THREE from "three";
 import { createTouchControls, notifyGameStarted, watchControlContext } from "@repo/embed";
 import type { PlayerMap } from "@vibedgames/multiplayer";
@@ -63,7 +64,7 @@ import {
   WORLD_HALF_Z,
   WORLD_W,
 } from "../shared/constants";
-import { isJsonString, parseJsonText } from "../shared/json";
+import { isFiniteJsonNumber, isJsonObject, isJsonString, parseJsonText } from "../shared/json";
 import type { GameMode } from "../shared/types";
 import { STAGE_MARGIN } from "../trailer/scout";
 import { GaragePreview } from "../ui/garage-preview";
@@ -261,6 +262,31 @@ const storageSet = (key: string, value: string): void => {
     window.localStorage.setItem(key, value);
   } catch {
     // Blocked store just loses persistence — never the run.
+  }
+};
+
+const SPAWN_KEY = "crazy-waymo:spawn";
+/** A stored spawn is data from an older build: every field is re-checked, and
+ *  the caller still runs it through the safety test against today's world. */
+const parseSpawn = (raw: string | null): PlayerSpawn | null => {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const value = parseJsonText(raw);
+    if (!isJsonObject(value)) {
+      return null;
+    }
+    const { x, z, yaw, gx, gz } = value;
+    return isFiniteJsonNumber(x) &&
+      isFiniteJsonNumber(z) &&
+      isFiniteJsonNumber(yaw) &&
+      isFiniteJsonNumber(gx) &&
+      isFiniteJsonNumber(gz)
+      ? { gx, gz, x, yaw, z }
+      : null;
+  } catch {
+    return null;
   }
 };
 
@@ -1743,15 +1769,26 @@ vec3 ocGerstner(vec2 p, float t) {
 
   // Revalidated after full readiness on every start. The early loading pose
   // uses available solids; actual play uses the complete static collision index.
+  // The spawn sticks between visits: the title gates on the tiles around it,
+  // so a returning player reloads a neighbourhood the browser already holds
+  // instead of downloading a fresh one. Trailers keep their own start.
   private computeSpawn(city: CityModel): WorldSpawn {
-    const spawn = choosePlayerSpawn({
+    const world = {
       decks: city.getDecks(),
-      heightAt: (x, z) => city.heightAt(x, z),
+      heightAt: (x: number, z: number) => city.heightAt(x, z),
       network: city.network,
       solids: this.solidIndex ?? new SolidIndex(city.solids),
-    });
+    };
+    const remembered = this.trailerMode ? null : parseSpawn(storageGet(SPAWN_KEY));
+    if (remembered && isPlayerSpawnSafe(world, remembered)) {
+      return remembered;
+    }
+    const spawn = choosePlayerSpawn(world);
     if (!spawn) {
       throw new Error("No safe player start exists in the street network");
+    }
+    if (!this.trailerMode) {
+      storageSet(SPAWN_KEY, JSON.stringify(spawn));
     }
     return spawn;
   }

--- a/games/crazy-waymo/src/vehicle/flotation.ts
+++ b/games/crazy-waymo/src/vehicle/flotation.ts
@@ -1,4 +1,4 @@
-import type RAPIER from "@dimforge/rapier3d-compat";
+import type * as RAPIER from "#rapier";
 import type { WaterSampler } from "../world/water";
 import { DRY_WATER_CONTACT } from "./water-contact";
 import type { FloatingWaterContact, WaterContact } from "./water-contact";

--- a/games/crazy-waymo/src/vehicle/raycast-vehicle.ts
+++ b/games/crazy-waymo/src/vehicle/raycast-vehicle.ts
@@ -1,5 +1,5 @@
-import { ColliderDesc, RigidBodyDesc } from "@dimforge/rapier3d-compat";
-import type { DynamicRayCastVehicleController, RigidBody, Vector } from "@dimforge/rapier3d-compat";
+import { ColliderDesc, RigidBodyDesc } from "#rapier";
+import type { DynamicRayCastVehicleController, RigidBody, Vector } from "#rapier";
 import * as THREE from "three";
 
 import type { PhysicsWorld } from "../physics/physics-world";

--- a/games/crazy-waymo/src/world/world-fetch.ts
+++ b/games/crazy-waymo/src/world/world-fetch.ts
@@ -18,16 +18,85 @@ const gunzip = async (gz: ArrayBuffer): Promise<ArrayBuffer> => {
 // paths — the rev query is what lets a rebake reach returning players.
 const bust = (path: string): string => `${path}?v=${WORLD_REV}`;
 
-const fetchGz = async (path: string): Promise<ArrayBuffer | null> => {
-  const res = await fetch(bust(path));
-  if (!res.ok) {
+// Phone browsers evict the HTTP cache under pressure, and every visit then
+// re-downloads its neighbourhood. Cache Storage is a second copy the browser
+// treats as site data, so returning players load tiles without the network.
+// One cache per world rev: opening the current one drops the rest.
+const CACHE_PREFIX = "crazy-waymo-world-";
+const worldCache = async (): Promise<Cache | null> => {
+  if (!("caches" in globalThis)) {
     return null;
   }
-  const buf = await res.arrayBuffer();
+  try {
+    const name = `${CACHE_PREFIX}${WORLD_REV}`;
+    const cache = await caches.open(name);
+    for (const key of await caches.keys()) {
+      if (key.startsWith(CACHE_PREFIX) && key !== name) {
+        void caches.delete(key);
+      }
+    }
+    return cache;
+  } catch {
+    // Cache Storage is unavailable in some private modes and sandboxed frames.
+    return null;
+  }
+};
+const cachePromise = worldCache();
+
+const isGzip = (buf: ArrayBuffer): boolean => {
   // SPA fallbacks answer 200 with index.html — a real artifact is binary
   // and starts with the gzip magic bytes.
   const head = new Uint8Array(buf, 0, 2);
-  return head[0] === 0x1f && head[1] === 0x8b ? buf : null;
+  return head[0] === 0x1f && head[1] === 0x8b;
+};
+
+const readCached = async (cache: Cache | null, url: string): Promise<ArrayBuffer | null> => {
+  if (!cache) {
+    return null;
+  }
+  try {
+    const hit = await cache.match(url);
+    if (!hit) {
+      return null;
+    }
+    const buf = await hit.arrayBuffer();
+    return isGzip(buf) ? buf : null;
+  } catch {
+    return null;
+  }
+};
+
+// Quota failures only cost the next visit its cache; the bytes are already
+// in hand, so nothing here may fail the load.
+const storeCached = async (cache: Cache | null, url: string, res: Response): Promise<void> => {
+  if (!cache) {
+    return;
+  }
+  try {
+    await cache.put(url, res);
+  } catch {
+    // out of quota or storage denied
+  }
+};
+
+const fetchGz = async (path: string): Promise<ArrayBuffer | null> => {
+  const url = bust(path);
+  const cache = await cachePromise;
+  const cached = await readCached(cache, url);
+  if (cached) {
+    return cached;
+  }
+  const res = await fetch(url);
+  if (!res.ok) {
+    return null;
+  }
+  const copy = res.clone();
+  const buf = await res.arrayBuffer();
+  if (!isGzip(buf)) {
+    return null;
+  }
+  void storeCached(cache, url, copy);
+  return buf;
 };
 
 const fetchBin = async (path: string): Promise<WorldBinPayload | null> => {

--- a/games/crazy-waymo/tools/test-flotation.mts
+++ b/games/crazy-waymo/tools/test-flotation.mts
@@ -1,4 +1,4 @@
-import { ColliderDesc, init, World } from "@dimforge/rapier3d-compat";
+import { ColliderDesc, ready, World } from "#rapier";
 import { Vector3 } from "three";
 import { RaycastVehicle } from "../src/vehicle/raycast-vehicle";
 import { waterBodyContains, waterBedHeight } from "../src/world/water";
@@ -215,7 +215,7 @@ const checkShoreCrossing = (check: Check): void => {
 };
 
 export const checkFlotation = async (check: Check): Promise<void> => {
-  await init();
+  await ready();
   const forwardCoastTravel = checkWaterEntry(check);
   checkWaterBrake(check, forwardCoastTravel);
   checkAuthoredWaterBodies(check);

--- a/games/crazy-waymo/tools/test-shoreline.mts
+++ b/games/crazy-waymo/tools/test-shoreline.mts
@@ -1,4 +1,4 @@
-import { ColliderDesc, init, World } from "@dimforge/rapier3d-compat";
+import { ColliderDesc, ready, World } from "#rapier";
 import { BatchedMesh, Matrix4, MeshStandardMaterial, Vector3 } from "three";
 import { propShadowsDisabled } from "../src/render/prop-shadow";
 import { staticSolidBox, staticSolidCollider } from "../src/physics/static-solid";
@@ -587,7 +587,7 @@ export const checkShoreline = async (check: Check): Promise<void> => {
 };
 
 export const checkShorelinePhysics = async (check: Check): Promise<void> => {
-  await init();
+  await ready();
   for (const diagonal of [false, true]) {
     const world = new World({ x: 0, y: -30, z: 0 });
     world.timestep = 1 / 60;

--- a/games/crazy-waymo/tools/test-vehicle-parking.mts
+++ b/games/crazy-waymo/tools/test-vehicle-parking.mts
@@ -1,11 +1,11 @@
-import { ColliderDesc, init, World } from "@dimforge/rapier3d-compat";
+import { ColliderDesc, ready, World } from "#rapier";
 import { RaycastVehicle } from "../src/vehicle/raycast-vehicle.ts";
 
 type Check = (name: string, passed: boolean, detail?: string) => void;
 
 /** A parked taxi must not slide sideways into a building on SF's hills. */
 export const checkVehicleParking = async (check: Check): Promise<void> => {
-  await init();
+  await ready();
   const world = new World({ x: 0, y: -30, z: 0 });
   world.timestep = 1 / 60;
   const pitch = Math.atan(0.4);

--- a/games/crazy-waymo/vite.config.ts
+++ b/games/crazy-waymo/vite.config.ts
@@ -1,12 +1,20 @@
 import { defineConfig } from "vite";
+import wasm from "vite-plugin-wasm";
 
 export default defineConfig({
   base: "./",
+  // Rapier's wasm arrives as a real .wasm asset (src/physics/rapier-browser.ts);
+  // the import is top-level-await, which every browser that runs this game
+  // already supports, so the build targets esnext rather than pulling in a
+  // TLA transform.
+  build: { target: "esnext" },
   define: {
     // Cache key for the IndexedDB world cache — every build invalidates it.
     __WORLD_BUILD_ID__: JSON.stringify(Date.now().toString(36)),
   },
+  optimizeDeps: { exclude: ["@dimforge/rapier3d"] },
   plugins: [
+    wasm(),
     {
       // Sim-critical modules must never hot-update: HMR re-instantiates a
       // second GameScene whose Rapier world is never stepped, and every

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,8 +524,8 @@ importers:
 
   games/crazy-waymo:
     dependencies:
-      '@dimforge/rapier3d-compat':
-        specifier: ^0.20.0
+      '@dimforge/rapier3d':
+        specifier: 0.20.0
         version: 0.20.0
       '@repo/embed':
         specifier: workspace:*
@@ -546,6 +546,9 @@ importers:
         specifier: ^0.185.1
         version: 0.185.1
     devDependencies:
+      '@dimforge/rapier3d-compat':
+        specifier: ^0.20.0
+        version: 0.20.0
       '@gltf-transform/core':
         specifier: ^4.4.2
         version: 4.4.2
@@ -573,6 +576,9 @@ importers:
       vite-node:
         specifier: ^6.0.0
         version: 6.0.0(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vite-plugin-wasm:
+        specifier: ^3.6.0
+        version: 3.6.0(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   games/farm:
     dependencies:
@@ -1424,6 +1430,9 @@ packages:
 
   '@dimforge/rapier3d-compat@0.20.0':
     resolution: {integrity: sha512-X4W9pJBdGRX5CO3c/gUNjBFEFG2fn4nYxp9k8STdBDaLa0/w5XTW2ArpayS+9jGFojTi3uFSOWAElCd4rkpekA==}
+
+  '@dimforge/rapier3d@0.20.0':
+    resolution: {integrity: sha512-Tj5dwOG5kXgcN/JRgOLTk64UFBd9KkaCAsWHcmPXOcyuBX6Vo7/ptSwS6zW++NvZebjJOW9/njmIqTM4VsaUog==}
 
   '@dotenvx/dotenvx@1.75.1':
     resolution: {integrity: sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ==}
@@ -5531,6 +5540,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  vite-plugin-wasm@3.6.0:
+    resolution: {integrity: sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6095,6 +6109,8 @@ snapshots:
   '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@dimforge/rapier3d-compat@0.20.0': {}
+
+  '@dimforge/rapier3d@0.20.0': {}
 
   '@dotenvx/dotenvx@1.75.1':
     dependencies:
@@ -9539,6 +9555,10 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-wasm@3.6.0(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
Phone boot pulled ~14 MB before the title and repeated most of it every visit (random spawn → new tiles; Android evicts the HTTP cache).

- **Rapier as a real wasm asset.** `@dimforge/rapier3d-compat` inlines 2.7 MB of base64 into the bundle. A `#rapier` package-imports alias hands browsers `@dimforge/rapier3d` (streamed `.wasm` via vite-plugin-wasm, `build.target: esnext` for the TLA) and vite-node tools the compat build under the `node` condition. Main bundle 1,899 → 611 KB gz; wasm is a separate 2 MB asset the browser caches and compiles off-thread. The games worker now gzips `application/wasm` (→ 774 KB on the wire).
- **Sticky spawn.** Stored in localStorage, parsed through the shared JSON guards, re-run through `isPlayerSpawnSafe` against today's world; trailers keep their own start.
- **Cache Storage for world artifacts** keyed by `WORLD_REV`, old revs dropped on open. Verified: warm load with the HTTP cache cleared fetches 0 world files.

Verified headless in preview and dev: boots to "Ready to drive", `pnpm test` 381/381, games worker 20/20, lint/format/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM9tKhTfFbGEhjL6WBPGBR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts phone boot from ~14 MB of downloads and stops repeating most of them every visit: Rapier ships as a streamed wasm asset instead of inlined base64, the player spawn is remembered between visits, and world files are cached in Cache Storage.

**Rapier as a wasm asset**
- A `#rapier` package-imports alias gives browsers the `@dimforge/rapier3d` raw-wasm build (streamed via `vite-plugin-wasm`) and vite-node tools the `@dimforge/rapier3d-compat` build under the `node` condition.
- Main bundle drops 1,899 → 611 KB gz; the 2 MB wasm is a separate asset the browser caches and compiles off-thread.
- The games worker now gzips `application/wasm`, so the wasm is 774 KB on the wire.

**Faster returning loads**
- The player spawn is saved to localStorage and re-checked with `isPlayerSpawnSafe` against the current world; trailers keep their own start.
- World artifacts are stored in Cache Storage keyed by `WORLD_REV`, with old revs dropped on open, so tiles survive phone HTTP-cache eviction.
- A warm load with the HTTP cache cleared fetches zero world files.

<sup>Written for commit cafb8b92fad78e4c33acc4d91270c5b861ef32ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

