### PR TITLE
crazy-waymo: phone floor — shorter world, smaller fabric ring, tier ceiling

### DIFF
--- a/games/crazy-waymo/src/render/day-night.ts
+++ b/games/crazy-waymo/src/render/day-night.ts
@@ -1,5 +1,7 @@
 import * as THREE from "three";
 
+import { reachScale } from "./quality";
+
 import { setGradeNight, setGradeWarmth } from "./grade";
 import { NightSky } from "./night-sky";
 import type { Sky } from "./sky";
@@ -550,8 +552,11 @@ export class DayNight {
     ambient.color.lerpColors(a.ambColor, b.ambColor, t);
 
     fog.color.copy(this.scrColor.lerpColors(a.fog, b.fog, t));
-    fog.near = THREE.MathUtils.lerp(a.fogNear, b.fogNear, t);
-    fog.far = THREE.MathUtils.lerp(a.fogFar, b.fogFar, t);
+    // The stops are authored against the desktop draw distance; a phone's
+    // shorter world needs the haze pulled in with it or the cull edge shows.
+    const reach = reachScale();
+    fog.near = THREE.MathUtils.lerp(a.fogNear, b.fogNear, t) * reach;
+    fog.far = THREE.MathUtils.lerp(a.fogFar, b.fogFar, t) * reach;
 
     // Night sky: the physical Sky shader is plain BLACK once the sun sets —
     // the horizon used to read as a hole in the world. Below the horizon,

--- a/games/crazy-waymo/src/render/perf-governor.ts
+++ b/games/crazy-waymo/src/render/perf-governor.ts
@@ -2,7 +2,7 @@ import type * as THREE from "three";
 
 import { FrameTimingWindow } from "./frame-timing-window";
 
-import { FULL_QUALITY, isCoarsePointer, setLiveQuality } from "./quality";
+import { FULL_QUALITY, PHONE_TOP_TIER, isCoarsePointer, setLiveQuality } from "./quality";
 import type { QualityFeatures } from "./quality";
 
 // Adaptive quality: keeps the game at target frame rate by stepping render
@@ -132,6 +132,8 @@ const installPerfDebug = (governor: PerfGovernor): void => {
 
 export class PerfGovernor {
   private readonly tiers: readonly Tier[];
+  // The best tier the governor may promote to (phones stop short of desktop).
+  private readonly topTier: number;
   private tier = 0;
   // grace at boot
   private cooldown = 1.5;
@@ -160,6 +162,7 @@ export class PerfGovernor {
     const native = Math.min(window.devicePixelRatio || 1, 2);
     const mobile = isCoarsePointer();
     this.tiers = qualityTiers(native, mobile);
+    this.topTier = mobile ? PHONE_TOP_TIER : 0;
     if (mobile) {
       // Boot LOW: the timing windows need ~10s to converge, and a phone
       // chugging through those first windows at desktop quality reads as a
@@ -234,7 +237,7 @@ export class PerfGovernor {
         this.upgradeCost = Math.min(UPGRADE_WINDOWS_MAX, this.upgradeCost * 2);
       }
       this.apply(this.tier + 1);
-    } else if (frameMs < FAST_MS && this.tier > 0) {
+    } else if (frameMs < FAST_MS && this.tier > this.topTier) {
       this.fastWindows += 1;
       if (this.fastWindows >= this.upgradeCost) {
         this.sinceUpgrade = 0;

--- a/games/crazy-waymo/src/render/quality.ts
+++ b/games/crazy-waymo/src/render/quality.ts
@@ -6,7 +6,28 @@
 // tiered budget for resolution, geometry and lighting. Drivers without
 // multi-draw also use instanced props to reduce submission cost.
 //
+import { DRAW_DISTANCE } from "../shared/constants";
+
 export const isCoarsePointer = (): boolean => window.matchMedia("(pointer: coarse)").matches;
+
+// Node tools import the world modules; there is no window there.
+const coarse = (): boolean => typeof window !== "undefined" && isCoarsePointer();
+
+// Phones see a shorter world. Resident GPU memory scales with the AREA inside
+// the draw distance, and a WebGL context lost to memory pressure is the one
+// failure a phone cannot recover from — Chrome then blocks the domain for the
+// session. 0.72 halves the resident tile ring (49 → 25 tiles) and the near
+// fabric band; the skyline imposters keep their own reach, so the horizon
+// still reads. Fog tracks the same scale so the cull edge stays hidden.
+export const PHONE_REACH = 0.72;
+export const reachScale = (): number => (coarse() ? PHONE_REACH : 1);
+export const drawDistance = (): number => Math.round(DRAW_DISTANCE * reachScale());
+
+// The tier a phone may climb to. Tiers 0-1 are desktop resolution and the full
+// model band; a phone that briefly measures fast enough would step into them,
+// grow its resident set, and be the phone that loses its context ten minutes
+// later. Boot starts below this and may rise to it, never past.
+export const PHONE_TOP_TIER = 2;
 
 // 2 = full sky (desktop look), 1 = halved counts + capped fog sheets,
 // 0 = no marine-layer sheets at all (scene fog + sky still sell the haze).

--- a/games/crazy-waymo/src/scenes/world-loader.ts
+++ b/games/crazy-waymo/src/scenes/world-loader.ts
@@ -18,7 +18,7 @@ import { PhysicsWorld } from "../physics/physics-world";
 import { Rng } from "../shared/rng";
 import { Car, skinById, skinModelUrl } from "../vehicle/car";
 import { RaycastVehicle } from "../vehicle/raycast-vehicle";
-import { CityModel, TILE_HOLD_RADIUS } from "../world/city";
+import { CityModel, tileHoldRadius } from "../world/city";
 import type { CityRestPayload } from "../world/city";
 import { editorMode, loadLocalOverrides } from "../world/custom-map";
 import { freewayPhysics } from "../world/freeways";
@@ -74,7 +74,7 @@ interface RestSource {
 // The title waits for the tiles this close to the spawn. A phone downloads
 // its neighbourhood and lets the rest stream in behind the title (the fog
 // hides most of it); a desktop pipe takes everything in draw range up front.
-const GATE_RADIUS = isCoarsePointer() ? 480 : TILE_HOLD_RADIUS;
+const GATE_RADIUS = isCoarsePointer() ? 480 : tileHoldRadius();
 
 interface WorldLoaderDeps {
   readonly scene: THREE.Scene;

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -10,7 +10,7 @@ import { createTerrainMaterial } from "../render/terrain-material";
 import { StaticWorldGroup } from "../render/static-world-group";
 import { propShadowPolicy, propShadowsDisabled, setPropShadowPolicy } from "../render/prop-shadow";
 import type { PropShadowPolicy } from "../render/prop-shadow";
-import { isCoarsePointer, liveQuality } from "../render/quality";
+import { drawDistance, isCoarsePointer, liveQuality } from "../render/quality";
 import { renderCapabilities } from "../render/capabilities";
 import { releaseArraysAfterUpload } from "../render/gpu-only-geometry";
 import { compatiblePropBatch } from "./instanced-props";
@@ -18,7 +18,6 @@ import type { PropBatch, PropInstance } from "./instanced-props";
 import {
   CHUNK,
   CITY_SEED,
-  DRAW_DISTANCE,
   GRID_X,
   GRID_Z,
   ROAD_TILE,
@@ -411,7 +410,7 @@ interface Chunk {
 }
 
 /** Tiles are held this far out — just past the merged chunks' own draw distance. */
-export const TILE_HOLD_RADIUS = DRAW_DISTANCE + 60;
+export const tileHoldRadius = (): number => drawDistance() + 60;
 
 // Batched-instance streaming scratch (per-frame, allocation-free).
 // cells this close are always on (off-screen shadow casters)
@@ -2224,7 +2223,7 @@ export class CityModel {
           await this.addMergedChunkRecords(records, fallbacks, ccx, ccz, dist, cullRadius);
         };
         if (main.length > 0) {
-          await publishMerged(main, DRAW_DISTANCE);
+          await publishMerged(main, drawDistance());
         }
         if (detail.length > 0) {
           await publishMerged(detail, DETAIL_DISTANCE);
@@ -2345,7 +2344,7 @@ export class CityModel {
       this.chunks.push({
         cx: tile.position.x,
         cz: tile.position.z,
-        dist: DRAW_DISTANCE,
+        dist: drawDistance(),
         group: tile,
         radius: 660,
       });
@@ -3031,7 +3030,7 @@ export class CityModel {
   updateStreaming(camera: THREE.Camera, showAll = false): void {
     const camX = camera.position.x;
     const camZ = camera.position.z;
-    this.tileStreamer?.update(camX, camZ, showAll ? Infinity : TILE_HOLD_RADIUS);
+    this.tileStreamer?.update(camX, camZ, showAll ? Infinity : tileHoldRadius());
     this.parcelStreamer?.update(
       camX,
       camZ,

--- a/games/crazy-waymo/src/world/parcel-mesh.ts
+++ b/games/crazy-waymo/src/world/parcel-mesh.ts
@@ -1,4 +1,5 @@
-import { CHUNK, DRAW_DISTANCE, ROAD_TILE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { CHUNK, ROAD_TILE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { drawDistance } from "../render/quality";
 import { Rng } from "../shared/rng";
 import { pointInRing } from "./parcel-plan";
 import type { ParcelLot, ParcelPlan } from "./parcel-plan";
@@ -2358,7 +2359,7 @@ export const tierDistance = (
       return midImposter;
     }
     case "near": {
-      return DRAW_DISTANCE;
+      return drawDistance();
     }
     case "detail": {
       return detail;

--- a/games/crazy-waymo/src/world/parcel-stream.ts
+++ b/games/crazy-waymo/src/world/parcel-stream.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 
-import { DRAW_DISTANCE, WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { WORLD_HALF_X, WORLD_HALF_Z } from "../shared/constants";
+import { drawDistance } from "../render/quality";
 import { parcelMeshOf } from "./parcel-build";
 import { buildParcelGeometrySteps } from "./parcel-mesh";
 import type { DetailLevel, ParcelGeometry } from "./parcel-mesh";
@@ -45,8 +46,12 @@ export const parcelDetailForDistance = (
 };
 
 /** Radius the fabric is held to, for a quality tier's model band. */
+// Low tiers and phones hold less fabric than the draw distance would fill;
+// the ring past it sits deep in the fog, and on a phone that ring is the
+// difference between a resident set the GPU process survives and one it
+// does not.
 export const streamRadiusFor = (detailScale: number, detail: DetailLevel = 2): number =>
-  (DRAW_DISTANCE + STREAM_PAD) * (detail === 1 || detailScale < 1 ? 0.72 : 1);
+  (drawDistance() + STREAM_PAD) * (detail === 1 || detailScale < 1 ? 0.72 : 1);
 
 export const streamCellKey = (x: number, z: number): number =>
   Math.floor((x + WORLD_HALF_X) / STREAM_CELL) * 4096 +


### PR DESCRIPTION
Reopens #348 on main (its stacked base was deleted when #347 merged).

A phone that loses its WebGL context to memory gets Chrome's per-domain block for the whole session, so the phone tier has to hold less world, not just draw it smaller.

- `drawDistance()` is 0.72× on a coarse pointer. The tile hold ring, merged-chunk and fabric cull bands, and the day-night fog stops all track it, so the cull edge stays behind the haze.
- The fabric streamer applies its low-tier 0.72 reach on phones as well.
- The governor never promotes a phone past tier 2 (0.66× native res, 0.78 model band, cadenced shadows). Boot stays at tier 3.

Emulated iPhone 14 Pro, fixed downtown spawn, tier 3: GPU geometry **100.3 → 82.3 MB** (fabric 35.5 → 26.0), 725 → 571 geometries. `pnpm test` 381/381, lint/format/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM9tKhTfFbGEhjL6WBPGBR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowers the phone's resident world size so a WebGL context lost to memory pressure — which Chrome punishes with a per-domain block for the whole session — stops being a realistic failure mode on mobile.

- `drawDistance()` returns 0.72× the desktop value on coarse pointers; the tile hold ring, merged-chunk and fabric cull bands, and day-night fog stops all track it so the cull edge stays behind the haze.
- The fabric streamer applies its low-tier 0.72 reach on phones as well.
- The perf governor never promotes a phone past tier 2 (0.66× native res, 0.78 model band, cadenced shadows) and still boots at tier 3.
- Measured on an emulated iPhone 14 Pro at a fixed downtown spawn, tier 3: GPU geometry 100.3 → 82.3 MB (fabric 35.5 → 26.0), 725 → 571 geometries.

<sup>Written for commit e7f28107b4c8c14a0a3950db0cf62929ba13d369. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

