### PR TITLE
Every game probes WebGL before boot and names a refused or lost context

### DIFF
--- a/games/battle-arena/src/main.ts
+++ b/games/battle-arena/src/main.ts
@@ -12,7 +12,9 @@ import {
   createTouchControls,
   isOfflineRequested,
   notifyGameStarted,
+  probeWebGL,
   setPauseHandlers,
+  showWebGLVeil,
 } from "@repo/embed";
 import * as THREE from "three";
 import { ModelLibrary } from "./render/models";
@@ -185,7 +187,20 @@ const showFailure = (cause: unknown): void => {
 };
 
 const main = async (): Promise<void> => {
+  const webgl = probeWebGL();
+  if (!webgl.ok) {
+    console.error(`WebGL unavailable: ${webgl.reason}`);
+    showWebGLVeil(webgl);
+    return;
+  }
   const view = new View(container);
+  view.renderer.domElement.addEventListener("webglcontextlost", () => {
+    console.error("WebGL context lost");
+    showWebGLVeil(
+      { blocked: false, ok: false, reason: "context lost" },
+      "The browser stopped the graphics (usually low memory).",
+    );
+  });
   const lib = new ModelLibrary();
   // in parallel with the model loads
   const bundledMapJob = fetchBundledMap();

--- a/games/bomberman/src/main.ts
+++ b/games/bomberman/src/main.ts
@@ -1,4 +1,4 @@
-import { setPauseHandlers } from "@repo/embed";
+import { probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 import type { Types } from "phaser";
 import { Game, Scale, WEBGL } from "phaser";
 
@@ -21,7 +21,21 @@ const config: Types.Core.GameConfig = {
   type: WEBGL,
 };
 
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
+}
+
 const game = new Game(config);
+game.canvas.addEventListener("webglcontextlost", () => {
+  console.error("WebGL context lost");
+  showWebGLVeil(
+    { blocked: false, ok: false, reason: "context lost" },
+    "The browser stopped the graphics (usually low memory).",
+  );
+});
 
 // Scale.RESIZE can read stale parent bounds when a resize lands while the tab
 // is hidden or the browser throttles events (tab switch, phone rotation): the

--- a/games/farm/src/main.ts
+++ b/games/farm/src/main.ts
@@ -1,6 +1,6 @@
 import type { Types } from "phaser";
 import { Game, Scale, WEBGL } from "phaser";
-import { setPauseHandlers } from "@repo/embed";
+import { probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 
 import { pauseOverlay } from "./pause-overlay";
 import { BootScene } from "./scenes/boot-scene";
@@ -41,7 +41,21 @@ declare global {
   }
 }
 
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
+}
+
 const game = new Game(config);
+game.canvas.addEventListener("webglcontextlost", () => {
+  console.error("WebGL context lost");
+  showWebGLVeil(
+    { blocked: false, ok: false, reason: "context lost" },
+    "The browser stopped the graphics (usually low memory).",
+  );
+});
 if (import.meta.env.DEV) {
   window.__game = game;
 }

--- a/games/flappy-dragons/src/main.ts
+++ b/games/flappy-dragons/src/main.ts
@@ -1,6 +1,6 @@
 import { Game, Scale, WEBGL } from "phaser";
 import type { Types } from "phaser";
-import { setPauseHandlers } from "@repo/embed";
+import { probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 
 import { CONTROLS } from "./controls";
 import { initPoseCamera } from "./input/camera";
@@ -35,7 +35,21 @@ const config: Types.Core.GameConfig = {
   type: WEBGL,
 };
 
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
+}
+
 const game = new Game(config);
+game.canvas.addEventListener("webglcontextlost", () => {
+  console.error("WebGL context lost");
+  showWebGLVeil(
+    { blocked: false, ok: false, reason: "context lost" },
+    "The browser stopped the graphics (usually low memory).",
+  );
+});
 
 // Scale.RESIZE can read stale parent bounds when a resize lands while the tab
 // is hidden or the browser throttles events (tab switch, phone rotation): the

--- a/games/lunerfall/src/main.ts
+++ b/games/lunerfall/src/main.ts
@@ -1,6 +1,6 @@
 import type { Types } from "phaser";
 import { Game, Scale, WEBGL } from "phaser";
-import { setPauseHandlers } from "@repo/embed";
+import { probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 
 import { sfx } from "./audio/sfx";
 import { BASE_H, BASE_W } from "./config";
@@ -25,7 +25,21 @@ const config: Types.Core.GameConfig = {
   type: WEBGL,
 };
 
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
+}
+
 const game = new Game(config);
+game.canvas.addEventListener("webglcontextlost", () => {
+  console.error("WebGL context lost");
+  showWebGLVeil(
+    { blocked: false, ok: false, reason: "context lost" },
+    "The browser stopped the graphics (usually low memory).",
+  );
+});
 // Debug handle for perf/inspection probes (see globalThis.__game).
 Reflect.set(globalThis, "__game", game);
 // __GAME_DIAGNOSTICS__ / __GAME_TEST_HOOKS__ for bot playtests (sys/diag.ts).

--- a/games/moba/src/main.ts
+++ b/games/moba/src/main.ts
@@ -1,6 +1,6 @@
 import type { Types } from "phaser";
 import { Game, Scale, WEBGL } from "phaser";
-import { setPauseHandlers } from "@repo/embed";
+import { probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 
 import { hide as hidePauseOverlay, show as showPauseOverlay } from "./pause-overlay";
 import { setSoundPaused, soundDiagnostics } from "./render/audio";
@@ -46,7 +46,20 @@ declare global {
 
 const boot = async (): Promise<void> => {
   await fontReady;
+  const webgl = probeWebGL();
+  if (!webgl.ok) {
+    console.error(`WebGL unavailable: ${webgl.reason}`);
+    showWebGLVeil(webgl);
+    return;
+  }
   const game = new Game(config);
+  game.canvas.addEventListener("webglcontextlost", () => {
+    console.error("WebGL context lost");
+    showWebGLVeil(
+      { blocked: false, ok: false, reason: "context lost" },
+      "The browser stopped the graphics (usually low memory).",
+    );
+  });
   const activeGame = (): GameScene | null => {
     const scene = game.scene.getScene("Game");
     return scene instanceof GameScene && game.scene.isActive("Game") ? scene : null;

--- a/games/pacman/src/main.ts
+++ b/games/pacman/src/main.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { setPauseHandlers } from "@repo/embed";
+import { probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 
 import { setAudioPaused, unlockAudio } from "./audio/sfx";
 import { FaceCamera } from "./input/face-camera";
@@ -21,6 +21,13 @@ if (IS_TOUCH) {
   document.body.classList.add("touch");
 }
 
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
+}
+
 const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: "high-performance" });
 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -31,6 +38,13 @@ renderer.toneMappingExposure = TONE_EXPOSURE;
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 container.append(renderer.domElement);
+renderer.domElement.addEventListener("webglcontextlost", () => {
+  console.error("WebGL context lost");
+  showWebGLVeil(
+    { blocked: false, ok: false, reason: "context lost" },
+    "The browser stopped the graphics (usually low memory).",
+  );
+});
 
 const game = new GameScene();
 

--- a/games/pong/src/main.ts
+++ b/games/pong/src/main.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { createTouchControls, setPauseHandlers } from "@repo/embed";
+import { createTouchControls, probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 
 import { isMuted, resumeSound, setMuted, setSoundPaused } from "./fx/sfx";
 import { createHandCamera } from "./input/camera";
@@ -13,6 +13,13 @@ import { COARSE_INPUT } from "./shared/input-mode";
 const container = document.querySelector("#game");
 if (!container) {
   throw new Error("missing #game container");
+}
+
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
 }
 
 // No MSAA: the scene renders into the dither pass's low-res target, where
@@ -33,6 +40,13 @@ const applyPixelRatio = (): void => {
 applyPixelRatio();
 renderer.setSize(window.innerWidth, window.innerHeight);
 container.append(renderer.domElement);
+renderer.domElement.addEventListener("webglcontextlost", () => {
+  console.error("WebGL context lost");
+  showWebGLVeil(
+    { blocked: false, ok: false, reason: "context lost" },
+    "The browser stopped the graphics (usually low memory).",
+  );
+});
 
 // Unlock audio on the first real gesture (capture: before that gesture serves).
 for (const event of ["pointerdown", "keydown"]) {

--- a/games/starfall/src/main.ts
+++ b/games/starfall/src/main.ts
@@ -1,5 +1,6 @@
 import type { Types } from "phaser";
 import { Game, Scale, WEBGL } from "phaser";
+import { probeWebGL, showWebGLVeil } from "@repo/embed";
 
 import { BootScene } from "./scenes/boot-scene";
 import { GameScene } from "./scenes/game-scene";
@@ -44,7 +45,21 @@ declare global {
   }
 }
 
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
+}
+
 const game = new Game(config);
+game.canvas.addEventListener("webglcontextlost", () => {
+  console.error("WebGL context lost");
+  showWebGLVeil(
+    { blocked: false, ok: false, reason: "context lost" },
+    "The browser stopped the graphics (usually low memory).",
+  );
+});
 if (import.meta.env.DEV) {
   window.__game = game;
 }

--- a/games/tetris/src/main.ts
+++ b/games/tetris/src/main.ts
@@ -1,4 +1,4 @@
-import { isPausable, pauseGame, setPauseHandlers } from "@repo/embed";
+import { isPausable, pauseGame, probeWebGL, setPauseHandlers, showWebGLVeil } from "@repo/embed";
 import * as THREE from "three";
 
 import { setSoundPaused } from "./fx/sfx";
@@ -15,6 +15,13 @@ if (!container) {
 }
 // Suppress long-press menus.
 container.addEventListener("contextmenu", (e) => e.preventDefault());
+
+const webgl = probeWebGL();
+if (!webgl.ok) {
+  showWebGLVeil(webgl);
+  // Module-level boot has no early return: the uncaught throw logs the reason and stops.
+  throw new Error(`WebGL unavailable: ${webgl.reason}`);
+}
 
 const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: "high-performance" });
 // Phones cap DPR lower — the antialiased 3D well is fill-rate bound at DPR 3.

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -31,3 +31,5 @@ export { sealPointerEvents } from "./pointer-seal";
 export type { PointerSealOptions } from "./pointer-seal";
 export { createTouchControls } from "./touch-controls";
 export type { TouchControls, TouchControlsOptions } from "./touch-controls";
+export { probeWebGL, showWebGLVeil, webglFailureMessage } from "./webgl";
+export type { WebGLProbe } from "./webgl";

--- a/packages/embed/src/webgl.ts
+++ b/packages/embed/src/webgl.ts
@@ -1,0 +1,89 @@
+// WebGL availability, asked before a game constructs its renderer.
+//
+// A refused context has three causes a player can act on, and the browser
+// tells the page which through `webglcontextcreationerror.statusMessage`.
+// The one that matters on this platform: Chrome blocks WebGL for the
+// TOP-LEVEL page's host for two minutes after a page under it loses its
+// context twice (GPU process killed for memory or a hung frame). Every game
+// is framed under vibedgames.com, so one crashing game refuses graphics to
+// the next nine a player opens — and a game that boots blind into
+// `new WebGLRenderer()` or Phaser `type: WEBGL` then shows a black canvas
+// with no explanation. Probe first, and say what happened.
+
+export type WebGLProbe =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      /** The browser's own reason, when it gave one. */
+      readonly reason: string;
+      /** Chrome's per-site block after repeated context loss — waiting clears it. */
+      readonly blocked: boolean;
+    };
+
+const BLOCK_PATTERN = /blocked|blocklist|too many|context limit/iu;
+
+/**
+ * Try to create a context on a throwaway canvas. Cheap: a probe context is
+ * released immediately, and the browser's creation-error event carries the
+ * reason a plain `getContext` swallows.
+ */
+export const probeWebGL = (): WebGLProbe => {
+  if (typeof document === "undefined") {
+    return { ok: true };
+  }
+  const canvas = document.createElement("canvas");
+  let reason = "";
+  canvas.addEventListener("webglcontextcreationerror", (event: Event) => {
+    if (event instanceof WebGLContextEvent && event.statusMessage) {
+      reason = event.statusMessage;
+    }
+  });
+  let gl: WebGLRenderingContext | WebGL2RenderingContext | null = null;
+  try {
+    gl = canvas.getContext("webgl2") ?? canvas.getContext("webgl");
+  } catch {
+    gl = null;
+  }
+  if (gl) {
+    gl.getExtension("WEBGL_lose_context")?.loseContext();
+    return { ok: true };
+  }
+  return { blocked: BLOCK_PATTERN.test(reason), ok: false, reason };
+};
+
+/** What to tell the player. Plain text; the game owns the surface it lands on. */
+export const webglFailureMessage = (probe: Extract<WebGLProbe, { ok: false }>): string => {
+  if (probe.blocked) {
+    return "Chrome paused graphics for this site after a game crashed. Wait two minutes, then reload.";
+  }
+  const detail = probe.reason ? ` (${probe.reason})` : "";
+  return `Graphics are unavailable in this browser${detail}. Try reloading, another browser, or enabling hardware acceleration.`;
+};
+
+const VEIL_ID = "vg-webgl-veil";
+
+/**
+ * A full-screen notice for a refused context, styled to sit over any game:
+ * dark ground, one line, tap to reload. Idempotent. `message` overrides the
+ * probe wording for a context lost mid-play, where "unavailable" misleads.
+ */
+export const showWebGLVeil = (
+  probe: Extract<WebGLProbe, { ok: false }>,
+  message: string = webglFailureMessage(probe),
+): void => {
+  if (typeof document === "undefined" || document.querySelector(`#${VEIL_ID}`)) {
+    return;
+  }
+  const veil = document.createElement("div");
+  veil.id = VEIL_ID;
+  veil.setAttribute("role", "alert");
+  veil.style.cssText =
+    "position:fixed;inset:0;z-index:2147483000;display:flex;align-items:center;justify-content:center;" +
+    "padding:24px;background:#0b0e14;color:#f4f7fb;font:15px/1.5 system-ui,sans-serif;text-align:center;cursor:pointer";
+  const text = document.createElement("div");
+  text.style.maxWidth = "28em";
+  text.textContent = `${message} Tap to reload.`;
+  veil.append(text);
+  veil.addEventListener("click", () => window.location.reload());
+  document.body.append(veil);
+};


### PR DESCRIPTION
Root cause of "seven games stopped loading on my phone": Chromium blocks WebGL for the **top-level page's host** for two minutes after a page under it loses its context twice (`gpu_data_manager_impl_private.cc`, `kBlockedDomainExpirationPeriod`). Games are iframed under `vibedgames.com`, so one game crashing the Pixel's GPU process (crazy-waymo) left every game opened in the next two minutes as a black canvas with no explanation. All ten games boot clean on an emulated Pixel 7 against prod; nothing in #327 is involved.

- `@repo/embed`: `probeWebGL()` (throwaway context + the browser's `webglcontextcreationerror.statusMessage`), `webglFailureMessage()`, `showWebGLVeil()`.
- All ten games probe before constructing Phaser/Three and show the veil on refusal; nine gain a `webglcontextlost` listener (tetris keeps its own restore path; crazy-waymo has its own handling).

Verified headless: blocked → "Chrome paused graphics for this site after a game crashed. Wait two minutes, then reload."; normal boot unchanged; live `loseContext()` → "The browser stopped the graphics (usually low memory). Tap to reload." Typecheck 13/13, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Games previously started their WebGL renderer without checking whether the browser would allow it, which could leave players with a black canvas or an unhandled renderer error. They now probe first and show a reload veil with an actionable reason; nine games also report a context loss during play instead of failing silently.

- Adds reusable `probeWebGL()`, `webglFailureMessage()`, and `showWebGLVeil()` helpers to `@repo/embed`.
- Identifies Chromium’s two-minute block after repeated context loss and tells players to wait; other failures suggest reloading, another browser, or hardware acceleration.
- Tetris keeps its existing context-restore handling.

<sup>Written for commit 84812b0cfba803e80021222e103e3faa48899ee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

