### PR TITLE
crazy-waymo: cull parked cars at the title, safe mode after a lost context

### DIFF
--- a/games/crazy-waymo/src/game/parked-cars.ts
+++ b/games/crazy-waymo/src/game/parked-cars.ts
@@ -1,3 +1,4 @@
+import { reachScale } from "../render/quality";
 import type { RigidBody } from "#rapier";
 import * as THREE from "three";
 
@@ -53,7 +54,8 @@ interface TemplatePart {
 const bucketKey = (p: TemplatePart): string => `${p.mat.uuid}|${geoLayoutKey(p.geo)}`;
 
 const CULL_DIST = 340;
-const CULL_DIST_SQ = CULL_DIST * CULL_DIST;
+// Phones see less street; the shorter world keeps its cars with it.
+const cullDistSq = (): number => (CULL_DIST * reachScale()) ** 2;
 
 export class ParkedCars {
   readonly group = new THREE.Group();
@@ -257,16 +259,28 @@ export class ParkedCars {
       return;
     }
     // full sweep every ~6 frames
-    const step = Math.max(1, Math.ceil(n / 6));
-    for (let i = 0; i < step; i += 1) {
-      const idx = (this.cullCursor + i) % n;
+    this.cullRange(camX, camZ, this.cullCursor, Math.max(1, Math.ceil(n / 6)));
+  }
+
+  /** One synchronous sweep of every car — for the first frame, before the
+   *  amortised cull has been round once. Every placed car starts visible, and
+   *  the title's hilltop orbit sees thousands of them at once otherwise. */
+  cullAll(camX: number, camZ: number): void {
+    this.cullRange(camX, camZ, 0, this.cars.length);
+  }
+
+  private cullRange(camX: number, camZ: number, from: number, count: number): void {
+    const n = this.cars.length;
+    const limit = cullDistSq();
+    for (let i = 0; i < count; i += 1) {
+      const idx = (from + i) % n;
       const c = this.cars[idx];
       if (!c) {
         continue;
       }
       const dx = c.x - camX;
       const dz = c.z - camZ;
-      const vis: 0 | 1 = c.hit || dx * dx + dz * dz < CULL_DIST_SQ ? 1 : 0;
+      const vis: 0 | 1 = c.hit || dx * dx + dz * dz < limit ? 1 : 0;
       if (this.visible[idx] !== vis) {
         this.visible[idx] = vis;
         for (const p of c.parts) {
@@ -274,7 +288,7 @@ export class ParkedCars {
         }
       }
     }
-    this.cullCursor = (this.cullCursor + step) % n;
+    this.cullCursor = (from + count) % n;
   }
 
   // The taxi rammed near (px,pz) moving at (vx,vz): hand the parked car it's

--- a/games/crazy-waymo/src/main.ts
+++ b/games/crazy-waymo/src/main.ts
@@ -6,6 +6,7 @@ import { hasReleasedArrays } from "./render/gpu-only-geometry";
 import { PerfGovernor } from "./render/perf-governor";
 import { PostPipeline } from "./render/post";
 import { setRenderCapabilities } from "./render/capabilities";
+import { recordContextLoss } from "./render/safe-mode";
 import { isCoarsePointer } from "./render/quality";
 import { GameScene } from "./scenes/game-scene";
 import { MAX_DT } from "./shared/constants";
@@ -86,15 +87,15 @@ const createRenderer = async (): Promise<THREE.WebGLRenderer> => {
       await sleep(350 * (i + 1));
     }
   }
-  // Chrome blocks WebGL for a domain for the rest of the browser session once
-  // a page has crashed the GPU process twice; only a full browser restart
-  // clears it, so a retry offer would be a lie.
+  // Chrome blocks WebGL for the top-level page's host for two minutes after
+  // a page under it loses its context twice. Retrying inside that window
+  // fails the same way, so the veil says to wait instead.
   const blocked = /blocked/iu.test(reason);
   showFatal(
     blocked
-      ? "Chrome blocked graphics for this site after a crash. Close Chrome fully (swipe it away from recents), reopen it, and come back."
+      ? "Chrome paused graphics for this site after a crash. Wait two minutes, then tap to reload."
       : `WebGL unavailable${reason ? ` (${reason})` : ""} — tap to retry, or enable hardware acceleration.`,
-    !blocked,
+    true,
   );
   throw lastError instanceof Error ? lastError : new Error("WebGL init failed");
 };
@@ -181,7 +182,11 @@ document.addEventListener("visibilitychange", () => {
 // one). three already asks the browser for restoration; if it comes, resume.
 renderer.domElement.addEventListener("webglcontextlost", () => {
   console.error("[crazy-waymo] WebGL context lost");
-  showFatal("The browser stopped the graphics (usually low memory). Tap to reload.", true);
+  recordContextLoss();
+  showFatal(
+    "The browser stopped the graphics (usually low memory). Tap to reload — the game will come back in low-graphics mode.",
+    true,
+  );
 });
 renderer.domElement.addEventListener("webglcontextrestored", () => {
   console.warn("[crazy-waymo] WebGL context restored");

--- a/games/crazy-waymo/src/render/material-breakup.ts
+++ b/games/crazy-waymo/src/render/material-breakup.ts
@@ -143,6 +143,14 @@ export const applyMaterialBreakup = (mat: THREE.Material, cfg: BreakupConfig): v
   if (!(mat instanceof THREE.MeshStandardMaterial)) {
     return;
   }
+  // Phones keep the stock program. The injection folds its config into the
+  // program cache key, so every material that carries a different config is
+  // its own ~90 KB fragment shader — over a hundred of them on a full city,
+  // and compiling that set is what a mobile GPU process does not survive.
+  // The breakup itself is a subtle albedo drift a phone screen barely shows.
+  if (isCoarsePointer()) {
+    return;
+  }
   if (mat.transparent || mat.polygonOffset) {
     return;
   }
@@ -166,7 +174,6 @@ export const applyMaterialBreakup = (mat: THREE.Material, cfg: BreakupConfig): v
       console.warn("[material-breakup] anchor missing, injection skipped:", mat.name || mat.uuid);
       return;
     }
-    const full = !isCoarsePointer();
     shader.vertexShader = shader.vertexShader
       .replace("#include <common>", "#include <common>\nvarying vec3 vKbWorld;")
       .replace(
@@ -188,7 +195,6 @@ ${VERT_ANCHOR}`,
       .replace(
         "#include <common>",
         `#include <common>
-${full ? "#define KB_MACRO_FULL 1" : ""}
 varying vec3 vKbWorld;
 float kbHash(vec2 p) { return fract(sin(dot(p, vec2(157.31, 269.53))) * 43758.5453); }
 float kbNoise(vec2 p) {
@@ -212,13 +218,11 @@ vec2 kbPlane(vec3 p, float period) { return (p.xz + p.y * 0.71) / period; }`,
         `{
   float kbA = kbNoise(kbPlane(vKbWorld, ${f(cfg.period)})) - 0.5;
   diffuseColor.rgb *= mix(vec3(1.0), mix(${hueRatio(cfg.cool)}, ${hueRatio(cfg.warm)}, kbA + 0.5), ${f(cfg.hueAmp)});
-#ifdef KB_MACRO_FULL
   float kbSettle = smoothstep(${f(cfg.settleNear)}, ${f(cfg.settleFar)}, distance(vKbWorld, cameraPosition));
   float kbB = kbNoise(kbPlane(vKbWorld, ${f(cfg.period * MACRO_PERIOD_RATIO)}) + vec2(0.19, 0.57)) - 0.5;
   diffuseColor.rgb *= 1.0 + kbB * ${f(cfg.valueAmp)} * (1.0 - kbSettle);
   float kbR = kbNoise(kbPlane(vKbWorld, ${f(cfg.period)}) + vec2(0.21, 0.83));
   roughnessFactor *= 1.0 - kbR * ${f(cfg.roughAmp)};
-#endif
   roughnessFactor = max(roughnessFactor, ${f(cfg.roughFloor)});
   vec3 kbDxy = max(abs(dFdx(normal)), abs(dFdy(normal)));
   float kbVar = min(max(max(kbDxy.x, kbDxy.y), kbDxy.z) * ${f(SPEC_AA_GAIN * cfg.specAA)}, ${f(SPEC_AA_CAP)});
@@ -227,7 +231,7 @@ vec2 kbPlane(vec3 p, float period) { return (p.xz + p.y * 0.71) / period; }`,
 ${FRAG_ANCHOR}`,
       );
   };
-  mat.customProgramCacheKey = () => `${prevKey}|${cfgKey}|${isCoarsePointer() ? "lo" : "hi"}`;
+  mat.customProgramCacheKey = () => `${prevKey}|${cfgKey}`;
   // A shared kit material may already have a compiled program (dynamic props
   // render during load); without the bump the renderer would keep it and the
   // injection would silently never run.

--- a/games/crazy-waymo/src/render/perf-governor.ts
+++ b/games/crazy-waymo/src/render/perf-governor.ts
@@ -4,6 +4,7 @@ import { FrameTimingWindow } from "./frame-timing-window";
 
 import { FULL_QUALITY, PHONE_TOP_TIER, isCoarsePointer, setLiveQuality } from "./quality";
 import type { QualityFeatures } from "./quality";
+import { safeMode } from "./safe-mode";
 
 // Adaptive quality: keeps the game at target frame rate by stepping render
 // resolution (and, at the floor tier, shadow resolution) instead of letting it
@@ -162,8 +163,17 @@ export class PerfGovernor {
     const native = Math.min(window.devicePixelRatio || 1, 2);
     const mobile = isCoarsePointer();
     this.tiers = qualityTiers(native, mobile);
-    this.topTier = mobile ? PHONE_TOP_TIER : 0;
-    if (mobile) {
+    const floor = this.tiers.length - 1;
+    if (safeMode()) {
+      // The floor is the tier without a shadow pass; a device that lost its
+      // context stays there for the visit.
+      this.topTier = floor;
+      this.apply(floor);
+      this.cooldown = 1.5;
+    } else {
+      this.topTier = mobile ? PHONE_TOP_TIER : 0;
+    }
+    if (mobile && !safeMode()) {
       // Boot LOW: the timing windows need ~10s to converge, and a phone
       // chugging through those first windows at desktop quality reads as a
       // broken game. Dense screens start at the deeper tier; upgrades are

--- a/games/crazy-waymo/src/render/quality.ts
+++ b/games/crazy-waymo/src/render/quality.ts
@@ -7,11 +7,11 @@
 // multi-draw also use instanced props to reduce submission cost.
 //
 import { DRAW_DISTANCE } from "../shared/constants";
+import { safeMode } from "./safe-mode";
 
-export const isCoarsePointer = (): boolean => window.matchMedia("(pointer: coarse)").matches;
-
-// Node tools import the world modules; there is no window there.
-const coarse = (): boolean => typeof window !== "undefined" && isCoarsePointer();
+// Node tools import the world modules at load; there is no window there.
+export const isCoarsePointer = (): boolean =>
+  typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches;
 
 // Phones see a shorter world. Resident GPU memory scales with the AREA inside
 // the draw distance, and a WebGL context lost to memory pressure is the one
@@ -20,7 +20,14 @@ const coarse = (): boolean => typeof window !== "undefined" && isCoarsePointer()
 // fabric band; the skyline imposters keep their own reach, so the horizon
 // still reads. Fog tracks the same scale so the cull edge stays hidden.
 export const PHONE_REACH = 0.72;
-export const reachScale = (): number => (coarse() ? PHONE_REACH : 1);
+// A device that already lost its context once holds a smaller world still.
+export const SAFE_REACH = 0.55;
+export const reachScale = (): number => {
+  if (safeMode()) {
+    return SAFE_REACH;
+  }
+  return isCoarsePointer() ? PHONE_REACH : 1;
+};
 export const drawDistance = (): number => Math.round(DRAW_DISTANCE * reachScale());
 
 // The tier a phone may climb to. Tiers 0-1 are desktop resolution and the full

--- a/games/crazy-waymo/src/render/safe-mode.ts
+++ b/games/crazy-waymo/src/render/safe-mode.ts
@@ -1,0 +1,56 @@
+// Low-graphics mode a device earns by losing its WebGL context. Chrome kills
+// the GPU process when a page's resident set or a frame's work exceeds what
+// the phone will carry, and after two kills it blocks WebGL for the domain for
+// the rest of the session — so the device that failed once must boot smaller
+// the next time without being asked. The flag lives in localStorage; `?safe=1`
+// forces it for a visit, `?safe=0` clears it.
+const KEY = "crazy-waymo:gpu-lost";
+
+const param = (): string | null => {
+  try {
+    return new URLSearchParams(window.location.search).get("safe");
+  } catch {
+    return null;
+  }
+};
+
+const stored = (): boolean => {
+  try {
+    return window.localStorage.getItem(KEY) !== null;
+  } catch {
+    return false;
+  }
+};
+
+export const clearSafeMode = (): void => {
+  try {
+    window.localStorage.removeItem(KEY);
+  } catch {
+    // nothing stored
+  }
+};
+
+let cached: boolean | null = null;
+
+export const safeMode = (): boolean => {
+  if (cached !== null) {
+    return cached;
+  }
+  const p = param();
+  if (p === "0") {
+    clearSafeMode();
+    cached = false;
+  } else {
+    cached = p === "1" || stored();
+  }
+  return cached;
+};
+
+/** Called from the context-lost handler: the next boot runs small. */
+export const recordContextLoss = (): void => {
+  try {
+    window.localStorage.setItem(KEY, String(Date.now()));
+  } catch {
+    // no persistence: the reload boots at the normal tier and may fail again
+  }
+};

--- a/games/crazy-waymo/src/scenes/game-scene.ts
+++ b/games/crazy-waymo/src/scenes/game-scene.ts
@@ -1,5 +1,6 @@
 import { choosePlayerSpawn, isPlayerSpawnSafe } from "../world/player-spawn";
 import type { PlayerSpawn } from "../world/player-spawn";
+import { safeMode } from "../render/safe-mode";
 import * as THREE from "three";
 import { createTouchControls, notifyGameStarted, watchControlContext } from "@repo/embed";
 import type { PlayerMap } from "@vibedgames/multiplayer";
@@ -265,6 +266,16 @@ const storageSet = (key: string, value: string): void => {
   }
 };
 
+// The note is the only sign the device is on the floor tier; without it a
+// player who compares phones reads the flatter city as a regression.
+const startBannerStats = (best: number): string => {
+  if (safeMode()) {
+    return "Low-graphics mode — the graphics stopped here last time. Add ?safe=0 to the address to retry full quality.";
+  }
+  return best > 0
+    ? `BEST $${best.toLocaleString("en-US")}`
+    : `Chain drop-offs to run the combo up to ${FARE.comboMax}×.`;
+};
 const SPAWN_KEY = "crazy-waymo:spawn";
 /** A stored spawn is data from an older build: every field is re-checked, and
  *  the caller still runs it through the safety test against today's world. */
@@ -1179,6 +1190,8 @@ vec3 ocGerstner(vec2 p, float t) {
       },
       onParked: (parked) => {
         this.parked = parked;
+        // The first frame must not draw every car in the city.
+        parked.cullAll(this.rig.camera.position.x, this.rig.camera.position.z);
       },
       onPhysics: (physics) => {
         this.physics = physics;
@@ -1327,10 +1340,7 @@ vec3 ocGerstner(vec2 p, float t) {
       // chat are left to be discovered.
       controls: bannerControls(),
       cta: this.touchUi ? "START DRIVING" : "START DRIVING ⏎",
-      stats:
-        best > 0
-          ? `BEST $${best.toLocaleString("en-US")}`
-          : `Chain drop-offs to run the combo up to ${FARE.comboMax}×.`,
+      stats: startBannerStats(best),
       sub: "Pick up fares, chain combos, drive like a maniac.",
       title: "CRAZY WAYMO",
     });
@@ -2109,6 +2119,9 @@ vec3 ocGerstner(vec2 p, float t) {
       car.position.z + Math.sin(a) * r,
     );
     this.rig.camera.lookAt(car.position.x, car.position.y + 1, car.position.z);
+    // The orbit is the one camera that sees the whole hillside: keep the
+    // parked-car cull running here, not only once driving starts.
+    this.parked?.updateCulling(this.rig.camera.position.x, this.rig.camera.position.z);
     // fade out leftover streaks
     this.speedLines?.update(dt, this.rig.camera, 0);
     // and drain the post lens the same way

--- a/games/crazy-waymo/src/scenes/world-loader.ts
+++ b/games/crazy-waymo/src/scenes/world-loader.ts
@@ -19,6 +19,7 @@ import { Rng } from "../shared/rng";
 import { Car, skinById, skinModelUrl } from "../vehicle/car";
 import { RaycastVehicle } from "../vehicle/raycast-vehicle";
 import { CityModel, tileHoldRadius } from "../world/city";
+import { safeMode } from "../render/safe-mode";
 import type { CityRestPayload } from "../world/city";
 import { editorMode, loadLocalOverrides } from "../world/custom-map";
 import { freewayPhysics } from "../world/freeways";
@@ -41,7 +42,7 @@ import type { ParcelSource } from "../world/parcel-source";
 import type { ParcelWorkerRequest, ParcelWorkerResponse } from "../world/parcel-worker";
 import { fetchBakedWorld, fetchParcelSource, fetchWorldMeta } from "../world/world-fetch";
 import type { CityRestMeta } from "../world/world-bin";
-import { isCoarsePointer } from "../render/quality";
+import { PHONE_REACH, SAFE_REACH, isCoarsePointer } from "../render/quality";
 import { Minimap } from "../ui/minimap";
 
 export type WorldSpawn = PlayerSpawn;
@@ -74,7 +75,11 @@ interface RestSource {
 // The title waits for the tiles this close to the spawn. A phone downloads
 // its neighbourhood and lets the rest stream in behind the title (the fog
 // hides most of it); a desktop pipe takes everything in draw range up front.
-const GATE_RADIUS = isCoarsePointer() ? 480 : tileHoldRadius();
+// A phone gates on a fixed ring around the spawn; safe mode shrinks it with
+// the rest of the reach so the title frame is smaller too.
+const GATE_RADIUS = isCoarsePointer()
+  ? Math.round(480 * (safeMode() ? SAFE_REACH / PHONE_REACH : 1))
+  : tileHoldRadius();
 
 interface WorldLoaderDeps {
   readonly scene: THREE.Scene;

--- a/games/crazy-waymo/src/world/city.ts
+++ b/games/crazy-waymo/src/world/city.ts
@@ -10,7 +10,8 @@ import { createTerrainMaterial } from "../render/terrain-material";
 import { StaticWorldGroup } from "../render/static-world-group";
 import { propShadowPolicy, propShadowsDisabled, setPropShadowPolicy } from "../render/prop-shadow";
 import type { PropShadowPolicy } from "../render/prop-shadow";
-import { drawDistance, isCoarsePointer, liveQuality } from "../render/quality";
+import { drawDistance, isCoarsePointer, liveQuality, reachScale } from "../render/quality";
+import { safeMode } from "../render/safe-mode";
 import { renderCapabilities } from "../render/capabilities";
 import { releaseArraysAfterUpload } from "../render/gpu-only-geometry";
 import { compatiblePropBatch } from "./instanced-props";
@@ -455,6 +456,12 @@ const TALL_DETAIL_DISTANCE = 700;
 // that had to get shorter.
 export const MID_IMPOSTER_DISTANCE = 1100;
 export const IMPOSTER_DISTANCE = 1400;
+// The imposter reach is kept on ordinary phones (the horizon is the look);
+// a device that already lost its context trades the far skyline for a
+// resident set it can carry.
+const imposterReach = (): number => (safeMode() ? reachScale() : 1);
+export const imposterDistance = (): number => IMPOSTER_DISTANCE * imposterReach();
+export const midImposterDistance = (): number => MID_IMPOSTER_DISTANCE * imposterReach();
 // --- Landmarks: the LOD unit is the STRUCTURE, not the member ---------------
 //
 // Every gate above asks how tall ONE instance is, which is the right question
@@ -1451,7 +1458,7 @@ export class CityModel {
     const built = await buildParcelFabric(
       skyline,
       [],
-      { detail: DETAIL_DISTANCE, imposter: IMPOSTER_DISTANCE, midImposter: MID_IMPOSTER_DISTANCE },
+      { detail: DETAIL_DISTANCE, imposter: imposterDistance(), midImposter: midImposterDistance() },
       detail,
       () => this.breathe(),
     );
@@ -2392,7 +2399,7 @@ export class CityModel {
     const built = await buildParcelFabric(
       skyline,
       [],
-      { detail: DETAIL_DISTANCE, imposter: IMPOSTER_DISTANCE, midImposter: MID_IMPOSTER_DISTANCE },
+      { detail: DETAIL_DISTANCE, imposter: imposterDistance(), midImposter: midImposterDistance() },
       detail,
       () => this.breathe(),
     );
@@ -3080,14 +3087,14 @@ export class CityModel {
     const cz = (Math.floor(key / nx) + 0.5) * STREAM_CELL - WORLD_HALF_Z;
     const dist = Math.hypot(camX - cx, camZ - cz);
     let inFrustum = false;
-    if (dist - pad < IMPOSTER_DISTANCE) {
+    if (dist - pad < imposterDistance()) {
       STREAM_SPHERE.center.set(cx, 14, cz);
       // tall roofs/trees overhang the tile
       STREAM_SPHERE.radius = pad + 30;
       inFrustum = STREAM_FRUSTUM.intersectsSphere(STREAM_SPHERE);
     }
     const near = dist < NEAR_ALWAYS;
-    const visFar: 0 | 1 = showAll || near || (inFrustum && dist - pad < IMPOSTER_DISTANCE) ? 1 : 0;
+    const visFar: 0 | 1 = showAll || near || (inFrustum && dist - pad < imposterDistance()) ? 1 : 0;
     // The model band tests the cell CENTRE, unpadded, while the imposter band
     // below keeps its half-diagonal pad: dropping a far cell too early leaves
     // a hole in the skyline, but swapping a near cell to its box too early
@@ -3142,7 +3149,7 @@ export class CityModel {
     this.imposterMidVisible ??= new Uint8Array(pass.total).fill(0);
     const visImp: 0 | 1 = visFar === 1 && visNear === 0 ? 1 : 0;
     flipImposters(this.imposterVisible, key, visImp, this.imposterInstances, mesh);
-    const visMid: 0 | 1 = visImp === 1 && dist - pass.pad < MID_IMPOSTER_DISTANCE ? 1 : 0;
+    const visMid: 0 | 1 = visImp === 1 && dist - pass.pad < midImposterDistance() ? 1 : 0;
     flipImposters(this.imposterMidVisible, key, visMid, this.imposterMidInstances, mesh);
   }
 


### PR DESCRIPTION
Pairs with #350. This is the game that crashes the Pixel's GPU process and triggers Chrome's site-wide block.

- **Parked-car cull at the title.** The hilltop orbit drew every parked car in the city (14,143 batched instances, 814k triangles, 43% of the frame) because `updateCulling` only ran in the drive loop. It now sweeps once at hand-off and every title frame, radius scaled by the phone reach.
- **Safe mode.** `webglcontextlost` records the loss in localStorage; the next boot pins the floor tier, shrinks reach to 0.55 (gate ring and imposter bands follow), and says so on the title. `?safe=1` forces, `?safe=0` clears.
- **Veil copy.** A "blocked" creation error now says to wait two minutes (Chromium's `kBlockedDomainExpirationPeriod`) instead of offering a retry that fails inside the window.
- Phones skip the material-breakup injection (measured: 2 programs, but a noise + derivative pass per fragment for nothing a phone screen shows).

Same spawn, 30-frame medians, emulated iPhone 14 Pro:

| | title tris | drive tris (floor tier) | drive calls |
|---|---|---|---|
| main | 2.51M | 1.20M | 336 |
| this PR | 1.14M | 1.15M | 334 |
| this PR, safe mode | 1.00M | 1.03M | 278 |

`pnpm test` 381/381, lint/format/typecheck green. Not verified on a physical Pixel — that is the test that matters, and the veil now reports the reason if it still fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the title screen drawing every parked car in the city, and adds a safe mode that boots a smaller world after a WebGL context loss so Chrome stops blocking the site.

- The parked-car cull now runs from the first frame and every title frame instead of only in the drive loop; title triangles drop from 2.51M to 1.14M on phones.
- A context loss writes to localStorage; the next boot pins the floor tier, shrinks reach to 0.55 with the gate ring and imposter bands following, and shows the mode on the title. `?safe=1` forces, `?safe=0` clears.
- The blocked-veil message now says to wait two minutes instead of offering a retry that fails inside Chrome's block window.
- Phones skip the material-breakup shader injection, saving 2 programs and a noise + derivative pass per fragment.

<sup>Written for commit 0acc2609e6c6b99065694cecb45182793ea913c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/vibedgames/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

